### PR TITLE
Restructure lockfile to reduce duplicated info

### DIFF
--- a/src/main/scala/software/purpledragon/sbt/lock/DependencyLockPlugin.scala
+++ b/src/main/scala/software/purpledragon/sbt/lock/DependencyLockPlugin.scala
@@ -55,7 +55,7 @@ object DependencyLockPlugin extends AutoPlugin {
       val currentFile = dependencyLockRead.value.getOrElse(sys.error("no lock file"))
       val updatedFile = DependencyUtils.resolve(updateReport, thisProject.value.configurations.map(_.toConfigRef))
 
-      if (currentFile.dependencies == updatedFile.dependencies) {
+      if (currentFile == updatedFile) {
         logger.info("Dependency lock check passed")
       } else {
         // TODO output info?

--- a/src/main/scala/software/purpledragon/sbt/lock/model/DependencyLockFile.scala
+++ b/src/main/scala/software/purpledragon/sbt/lock/model/DependencyLockFile.scala
@@ -17,8 +17,22 @@
 package software.purpledragon.sbt.lock.model
 
 import java.time.Instant
+import java.util.Objects
 
 final case class DependencyLockFile(
     lockVersion: Int,
     timestamp: Instant,
-    dependencies: Map[String, Seq[ResolvedDependency]])
+    configurations: Seq[String],
+    dependencies: Seq[ResolvedDependency]) {
+
+  override def hashCode(): Int = Objects.hash(int2Integer(lockVersion), configurations, dependencies)
+
+  override def equals(obj: Any): Boolean = {
+    obj match {
+      case other: DependencyLockFile =>
+        lockVersion == other.lockVersion && configurations == other.configurations && dependencies == other.dependencies
+      case _ =>
+        false
+    }
+  }
+}

--- a/src/main/scala/software/purpledragon/sbt/lock/model/ResolvedDependency.scala
+++ b/src/main/scala/software/purpledragon/sbt/lock/model/ResolvedDependency.scala
@@ -18,10 +18,19 @@ package software.purpledragon.sbt.lock.model
 
 import scala.math.Ordered.orderingToOrdered
 
-final case class ResolvedDependency(org: String, name: String, version: String, artifacts: Seq[ResolvedArtifact])
+final case class ResolvedDependency(
+    org: String,
+    name: String,
+    version: String,
+    artifacts: Seq[ResolvedArtifact],
+    configurations: Set[String])
     extends Ordered[ResolvedDependency] {
 
   override def compare(that: ResolvedDependency): Int = {
     (org, name, version) compare (that.org, that.name, that.version)
+  }
+
+  def withConfiguration(conf: String): ResolvedDependency = {
+    copy(configurations = configurations + conf)
   }
 }

--- a/src/sbt-test/sbt-dependency-lock/check-fail/build.sbt.lock
+++ b/src/sbt-test/sbt-dependency-lock/check-fail/build.sbt.lock
@@ -1,126 +1,101 @@
 {
   "lockVersion" : 1,
-  "timestamp" : "2019-10-24T12:24:55.659Z",
-  "dependencies" : {
-    "test" : [
-      {
-        "org" : "org.apache.commons",
-        "name" : "commons-lang3",
-        "version" : "3.9",
-        "artifacts" : [
-          {
-            "name" : "commons-lang3",
-            "hash" : "sha1:0122c7cee69b53ed4a7681c03d4ee4c0e2765da5"
-          }
-        ]
-      },
-      {
-        "org" : "org.scala-lang",
-        "name" : "scala-library",
-        "version" : "2.12.10",
-        "artifacts" : [
-          {
-            "name" : "scala-library",
-            "hash" : "sha1:3509860bc2e5b3da001ed45aca94ffbe5694dbda"
-          }
-        ]
-      },
-      {
-        "org" : "org.scala-lang",
-        "name" : "scala-reflect",
-        "version" : "2.12.10",
-        "artifacts" : [
-          {
-            "name" : "scala-reflect",
-            "hash" : "sha1:14cb7beb516cd8e07716133668c427792122c926"
-          }
-        ]
-      },
-      {
-        "org" : "org.scala-lang.modules",
-        "name" : "scala-xml_2.12",
-        "version" : "1.2.0",
-        "artifacts" : [
-          {
-            "name" : "scala-xml_2.12",
-            "hash" : "sha1:5d38ac30beb8420dd395c0af447ba412158965e6"
-          }
-        ]
-      },
-      {
-        "org" : "org.scalactic",
-        "name" : "scalactic_2.12",
-        "version" : "3.0.8",
-        "artifacts" : [
-          {
-            "name" : "scalactic_2.12",
-            "hash" : "sha1:b50559dfc4a691c1089f9c8812e1d6fd17f80277"
-          }
-        ]
-      },
-      {
-        "org" : "org.scalatest",
-        "name" : "scalatest_2.12",
-        "version" : "3.0.8",
-        "artifacts" : [
-          {
-            "name" : "scalatest_2.12",
-            "hash" : "sha1:8493ffa579676977b810a7a9fdc23af9d3c8af7f"
-          }
-        ]
-      }
-    ],
-    "provided" : [
-    ],
-    "optional" : [
-    ],
-    "compile" : [
-      {
-        "org" : "org.apache.commons",
-        "name" : "commons-lang3",
-        "version" : "3.9",
-        "artifacts" : [
-          {
-            "name" : "commons-lang3",
-            "hash" : "sha1:0122c7cee69b53ed4a7681c03d4ee4c0e2765da5"
-          }
-        ]
-      },
-      {
-        "org" : "org.scala-lang",
-        "name" : "scala-library",
-        "version" : "2.12.10",
-        "artifacts" : [
-          {
-            "name" : "scala-library",
-            "hash" : "sha1:3509860bc2e5b3da001ed45aca94ffbe5694dbda"
-          }
-        ]
-      }
-    ],
-    "runtime" : [
-      {
-        "org" : "org.apache.commons",
-        "name" : "commons-lang3",
-        "version" : "3.9",
-        "artifacts" : [
-          {
-            "name" : "commons-lang3",
-            "hash" : "sha1:0122c7cee69b53ed4a7681c03d4ee4c0e2765da5"
-          }
-        ]
-      },
-      {
-        "org" : "org.scala-lang",
-        "name" : "scala-library",
-        "version" : "2.12.10",
-        "artifacts" : [
-          {
-            "name" : "scala-library",
-            "hash" : "sha1:3509860bc2e5b3da001ed45aca94ffbe5694dbda"
-          }
-        ]
-      }
-    ]
-  }
+  "timestamp" : "2019-10-28T17:12:35.793Z",
+  "configurations" : [
+    "compile",
+    "optional",
+    "provided",
+    "runtime",
+    "test"
+  ],
+  "dependencies" : [
+    {
+      "org" : "org.scala-lang",
+      "name" : "scala-library",
+      "version" : "2.12.10",
+      "artifacts" : [
+        {
+          "name" : "scala-library",
+          "hash" : "sha1:3509860bc2e5b3da001ed45aca94ffbe5694dbda"
+        }
+      ],
+      "configurations" : [
+        "test",
+        "compile",
+        "runtime"
+      ]
+    },
+    {
+      "org" : "org.scalactic",
+      "name" : "scalactic_2.12",
+      "version" : "3.0.8",
+      "artifacts" : [
+        {
+          "name" : "scalactic_2.12",
+          "hash" : "sha1:b50559dfc4a691c1089f9c8812e1d6fd17f80277"
+        }
+      ],
+      "configurations" : [
+        "test"
+      ]
+    },
+    {
+      "org" : "org.scala-lang",
+      "name" : "scala-reflect",
+      "version" : "2.12.10",
+      "artifacts" : [
+        {
+          "name" : "scala-reflect",
+          "hash" : "sha1:14cb7beb516cd8e07716133668c427792122c926"
+        }
+      ],
+      "configurations" : [
+        "test"
+      ]
+    },
+    {
+      "org" : "org.scalatest",
+      "name" : "scalatest_2.12",
+      "version" : "3.0.8",
+      "artifacts" : [
+        {
+          "name" : "scalatest_2.12",
+          "hash" : "sha1:8493ffa579676977b810a7a9fdc23af9d3c8af7f"
+        }
+      ],
+      "configurations" : [
+        "test"
+      ]
+    },
+    {
+      "org" : "org.apache.commons",
+      "name" : "commons-lang3",
+      "version" : "3.9",
+      "artifacts" : [
+        {
+          "name" : "commons-lang3",
+          "hash" : "sha1:0122c7cee69b53ed4a7681c03d4ee4c0e2765da5"
+        }
+      ],
+      "configurations" : [
+        "test",
+        "compile",
+        "runtime"
+      ]
+    },
+    {
+      "org" : "org.scala-lang.modules",
+      "name" : "scala-xml_2.12",
+      "version" : "1.2.0",
+      "artifacts" : [
+        {
+          "name" : "scala-xml_2.12",
+          "hash" : "sha1:5d38ac30beb8420dd395c0af447ba412158965e6"
+        }
+      ],
+      "configurations" : [
+        "test"
+      ]
+    }
+  ]
 }

--- a/src/sbt-test/sbt-dependency-lock/check-pass/build.sbt.lock
+++ b/src/sbt-test/sbt-dependency-lock/check-pass/build.sbt.lock
@@ -1,126 +1,101 @@
 {
   "lockVersion" : 1,
-  "timestamp" : "2019-10-24T12:24:55.659Z",
-  "dependencies" : {
-    "test" : [
-      {
-        "org" : "org.apache.commons",
-        "name" : "commons-lang3",
-        "version" : "3.9",
-        "artifacts" : [
-          {
-            "name" : "commons-lang3",
-            "hash" : "sha1:0122c7cee69b53ed4a7681c03d4ee4c0e2765da5"
-          }
-        ]
-      },
-      {
-        "org" : "org.scala-lang",
-        "name" : "scala-library",
-        "version" : "2.12.10",
-        "artifacts" : [
-          {
-            "name" : "scala-library",
-            "hash" : "sha1:3509860bc2e5b3da001ed45aca94ffbe5694dbda"
-          }
-        ]
-      },
-      {
-        "org" : "org.scala-lang",
-        "name" : "scala-reflect",
-        "version" : "2.12.10",
-        "artifacts" : [
-          {
-            "name" : "scala-reflect",
-            "hash" : "sha1:14cb7beb516cd8e07716133668c427792122c926"
-          }
-        ]
-      },
-      {
-        "org" : "org.scala-lang.modules",
-        "name" : "scala-xml_2.12",
-        "version" : "1.2.0",
-        "artifacts" : [
-          {
-            "name" : "scala-xml_2.12",
-            "hash" : "sha1:5d38ac30beb8420dd395c0af447ba412158965e6"
-          }
-        ]
-      },
-      {
-        "org" : "org.scalactic",
-        "name" : "scalactic_2.12",
-        "version" : "3.0.8",
-        "artifacts" : [
-          {
-            "name" : "scalactic_2.12",
-            "hash" : "sha1:b50559dfc4a691c1089f9c8812e1d6fd17f80277"
-          }
-        ]
-      },
-      {
-        "org" : "org.scalatest",
-        "name" : "scalatest_2.12",
-        "version" : "3.0.8",
-        "artifacts" : [
-          {
-            "name" : "scalatest_2.12",
-            "hash" : "sha1:8493ffa579676977b810a7a9fdc23af9d3c8af7f"
-          }
-        ]
-      }
-    ],
-    "provided" : [
-    ],
-    "optional" : [
-    ],
-    "compile" : [
-      {
-        "org" : "org.apache.commons",
-        "name" : "commons-lang3",
-        "version" : "3.9",
-        "artifacts" : [
-          {
-            "name" : "commons-lang3",
-            "hash" : "sha1:0122c7cee69b53ed4a7681c03d4ee4c0e2765da5"
-          }
-        ]
-      },
-      {
-        "org" : "org.scala-lang",
-        "name" : "scala-library",
-        "version" : "2.12.10",
-        "artifacts" : [
-          {
-            "name" : "scala-library",
-            "hash" : "sha1:3509860bc2e5b3da001ed45aca94ffbe5694dbda"
-          }
-        ]
-      }
-    ],
-    "runtime" : [
-      {
-        "org" : "org.apache.commons",
-        "name" : "commons-lang3",
-        "version" : "3.9",
-        "artifacts" : [
-          {
-            "name" : "commons-lang3",
-            "hash" : "sha1:0122c7cee69b53ed4a7681c03d4ee4c0e2765da5"
-          }
-        ]
-      },
-      {
-        "org" : "org.scala-lang",
-        "name" : "scala-library",
-        "version" : "2.12.10",
-        "artifacts" : [
-          {
-            "name" : "scala-library",
-            "hash" : "sha1:3509860bc2e5b3da001ed45aca94ffbe5694dbda"
-          }
-        ]
-      }
-    ]
-  }
+  "timestamp" : "2019-10-28T17:12:35.793Z",
+  "configurations" : [
+    "compile",
+    "optional",
+    "provided",
+    "runtime",
+    "test"
+  ],
+  "dependencies" : [
+    {
+      "org" : "org.scala-lang",
+      "name" : "scala-library",
+      "version" : "2.12.10",
+      "artifacts" : [
+        {
+          "name" : "scala-library",
+          "hash" : "sha1:3509860bc2e5b3da001ed45aca94ffbe5694dbda"
+        }
+      ],
+      "configurations" : [
+        "test",
+        "compile",
+        "runtime"
+      ]
+    },
+    {
+      "org" : "org.scalactic",
+      "name" : "scalactic_2.12",
+      "version" : "3.0.8",
+      "artifacts" : [
+        {
+          "name" : "scalactic_2.12",
+          "hash" : "sha1:b50559dfc4a691c1089f9c8812e1d6fd17f80277"
+        }
+      ],
+      "configurations" : [
+        "test"
+      ]
+    },
+    {
+      "org" : "org.scala-lang",
+      "name" : "scala-reflect",
+      "version" : "2.12.10",
+      "artifacts" : [
+        {
+          "name" : "scala-reflect",
+          "hash" : "sha1:14cb7beb516cd8e07716133668c427792122c926"
+        }
+      ],
+      "configurations" : [
+        "test"
+      ]
+    },
+    {
+      "org" : "org.scalatest",
+      "name" : "scalatest_2.12",
+      "version" : "3.0.8",
+      "artifacts" : [
+        {
+          "name" : "scalatest_2.12",
+          "hash" : "sha1:8493ffa579676977b810a7a9fdc23af9d3c8af7f"
+        }
+      ],
+      "configurations" : [
+        "test"
+      ]
+    },
+    {
+      "org" : "org.apache.commons",
+      "name" : "commons-lang3",
+      "version" : "3.9",
+      "artifacts" : [
+        {
+          "name" : "commons-lang3",
+          "hash" : "sha1:0122c7cee69b53ed4a7681c03d4ee4c0e2765da5"
+        }
+      ],
+      "configurations" : [
+        "test",
+        "compile",
+        "runtime"
+      ]
+    },
+    {
+      "org" : "org.scala-lang.modules",
+      "name" : "scala-xml_2.12",
+      "version" : "1.2.0",
+      "artifacts" : [
+        {
+          "name" : "scala-xml_2.12",
+          "hash" : "sha1:5d38ac30beb8420dd395c0af447ba412158965e6"
+        }
+      ],
+      "configurations" : [
+        "test"
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
This restructures the lockfile so that configurations are stored against dependencies instead of the other way round.