### PR TITLE
Improve formatting of long dependency reports

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,8 @@ libraryDependencies ++= Seq(
 ).map(_ % circeVersion)
 
 libraryDependencies ++= Seq(
-  "org.scalatest" %% "scalatest" % "3.1.0" % Test
+  "software.purpledragon" %% "text-utils" % "1.2.0",
+  "org.scalatest"         %% "scalatest"  % "3.1.0" % Test
 )
 
 organizationName := "Michael Stringer"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.2
+sbt.version=1.3.8

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -43,12 +43,3 @@ lock.status.full.dependencies.removed.multiple=\ \ {0} dependencies removed:\n{1
 lock.status.full.dependencies.changed.none=
 lock.status.full.dependencies.changed.singular=\ \ 1 dependency changed:\n{1}
 lock.status.full.dependencies.changed.multiple=\ \ {0} dependencies changed:\n{1}
-
-#com.example:artifact:1.0 (compile,test)
-lock.status.full.dependency=\ \ \ \ {0}:{1}:{2} ({3})
-#com.example:artifact:[1.0]->[2.0] (compile,test)
-lock.status.full.dependency.changed.version=\ \ \ \ {0}:{1}:[{2}]->[{3}] ({4})
-#com.example:artifact:1.0 (compile,test)->(compile)
-lock.status.full.dependency.changed.configs=\ \ \ \ {0}:{1}:{2} ({4})->({5})
-#com.example:artifact:[1.0]->[2.0] (compile,test)->(compile)
-lock.status.full.dependency.changed.all=\ \ \ \ {0}:{1}:[{2}]->[{3}] ({4})->({5})

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -20,6 +20,11 @@ lock.status.dependencies.none=no dependencies
 lock.status.dependencies.singular=1 dependency
 lock.status.dependencies.multiple={0} dependencies
 
+# lockfile short status - artifacts ============================================
+lock.status.artifacts.changed.none=
+lock.status.artifacts.changed.singular=\ \ 1 dependency artifacts changed
+lock.status.artifacts.changed.multiple=\ \ {0} dependency artifacts changed
+
 # lockfile full status - configurations =======================================
 
 lock.status.full.configs.added.none=
@@ -45,7 +50,6 @@ lock.status.full.dependencies.changed.singular=\ \ 1 dependency changed:\n{1}
 lock.status.full.dependencies.changed.multiple=\ \ {0} dependencies changed:\n{1}
 
 # lockfile full status - artifacts ============================================
-
 lock.status.full.artifacts.changed.none=
 lock.status.full.artifacts.changed.singular=\ \ 1 dependency artifacts changed
 lock.status.full.artifacts.changed.multiple=\ \ {0} dependency artifacts changed

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -43,3 +43,9 @@ lock.status.full.dependencies.removed.multiple=\ \ {0} dependencies removed:\n{1
 lock.status.full.dependencies.changed.none=
 lock.status.full.dependencies.changed.singular=\ \ 1 dependency changed:\n{1}
 lock.status.full.dependencies.changed.multiple=\ \ {0} dependencies changed:\n{1}
+
+# lockfile full status - artifacts ============================================
+
+lock.status.full.artifacts.changed.none=
+lock.status.full.artifacts.changed.singular=\ \ 1 dependency artifacts changed
+lock.status.full.artifacts.changed.multiple=\ \ {0} dependency artifacts changed

--- a/src/main/scala/software/purpledragon/sbt/lock/DependencyUtils.scala
+++ b/src/main/scala/software/purpledragon/sbt/lock/DependencyUtils.scala
@@ -80,7 +80,7 @@ object DependencyUtils {
       module.module.organization,
       module.module.name,
       module.module.revision,
-      artifacts,
+      artifacts.to[SortedSet],
       SortedSet.empty)
   }
 

--- a/src/main/scala/software/purpledragon/sbt/lock/DependencyUtils.scala
+++ b/src/main/scala/software/purpledragon/sbt/lock/DependencyUtils.scala
@@ -21,7 +21,7 @@ import java.time.Instant
 import sbt._
 import software.purpledragon.sbt.lock.model.{DependencyLockFile, DependencyRef, ResolvedArtifact, ResolvedDependency}
 
-import scala.collection.{immutable, mutable}
+import scala.collection.{immutable, mutable, SortedSet}
 
 object DependencyUtils {
   def resolve(updateReport: UpdateReport, configs: Seq[ConfigRef]): DependencyLockFile = {
@@ -76,7 +76,12 @@ object DependencyUtils {
         ResolvedArtifact(s"${artifact.name}$qualifier.${artifact.extension}", hash)
     }
 
-    ResolvedDependency(module.module.organization, module.module.name, module.module.revision, artifacts, Set.empty)
+    ResolvedDependency(
+      module.module.organization,
+      module.module.name,
+      module.module.revision,
+      artifacts,
+      SortedSet.empty)
   }
 
   private def hashFile(file: File): String = s"sha1:${Hash.toHex(Hash(file))}"

--- a/src/main/scala/software/purpledragon/sbt/lock/model/ChangedDependency.scala
+++ b/src/main/scala/software/purpledragon/sbt/lock/model/ChangedDependency.scala
@@ -16,15 +16,17 @@
 
 package software.purpledragon.sbt.lock.model
 
+import scala.collection.SortedSet
+
 final case class ChangedDependency(
     org: String,
     name: String,
     oldVersion: String,
     newVersion: String,
-    oldArtifacts: Seq[ResolvedArtifact],
-    newArtifacts: Seq[ResolvedArtifact],
-    oldConfigurations: Set[String],
-    newConfigurations: Set[String]) {
+    oldArtifacts: SortedSet[ResolvedArtifact],
+    newArtifacts: SortedSet[ResolvedArtifact],
+    oldConfigurations: SortedSet[String],
+    newConfigurations: SortedSet[String]) {
 
   def versionChanged: Boolean = oldVersion != newVersion
   def configurationsChanged: Boolean = oldConfigurations != newConfigurations

--- a/src/main/scala/software/purpledragon/sbt/lock/model/DependencyLockFile.scala
+++ b/src/main/scala/software/purpledragon/sbt/lock/model/DependencyLockFile.scala
@@ -82,8 +82,8 @@ final case class DependencyLockFile(
             otherDep.version,
             ourDep.artifacts,
             otherDep.artifacts,
-            ourDep.configurations,
-            otherDep.configurations)
+            ourDep.configurations.toSet,
+            otherDep.configurations.toSet)
         } else {
           changes
         }

--- a/src/main/scala/software/purpledragon/sbt/lock/model/DependencyLockFile.scala
+++ b/src/main/scala/software/purpledragon/sbt/lock/model/DependencyLockFile.scala
@@ -82,8 +82,8 @@ final case class DependencyLockFile(
             otherDep.version,
             ourDep.artifacts,
             otherDep.artifacts,
-            ourDep.configurations.toSet,
-            otherDep.configurations.toSet)
+            ourDep.configurations,
+            otherDep.configurations)
         } else {
           changes
         }

--- a/src/main/scala/software/purpledragon/sbt/lock/model/LockFileStatus.scala
+++ b/src/main/scala/software/purpledragon/sbt/lock/model/LockFileStatus.scala
@@ -135,8 +135,7 @@ final case class LockFileDiffers(
     }
 
     def dumpChanges(changes: Seq[ChangedDependency]): String = {
-      val table =
-        new TableFormatter(None, prefix = "    ", stripTrailingNewline = true)
+      val table = new TableFormatter(None, prefix = "    ", stripTrailingNewline = true)
 
       changes foreach { change =>
         table.addRow(
@@ -153,11 +152,18 @@ final case class LockFileDiffers(
       table.toString()
     }
 
-    if (changedDependencies.nonEmpty) {
+    val (depChanged, artChanged) =
+      changedDependencies.partition(change => change.configurationsChanged || change.versionChanged)
+
+    if (depChanged.nonEmpty) {
       errors += MessageUtil.formatPlural(
         "lock.status.full.dependencies.changed",
-        changedDependencies.size,
-        dumpChanges(changedDependencies))
+        depChanged.size,
+        dumpChanges(depChanged))
+    }
+
+    if (artChanged.nonEmpty) {
+      errors += MessageUtil.formatPlural("lock.status.full.artifacts.changed", artChanged.size)
     }
 
     MessageUtil.formatMessage("lock.status.failed.long", errors.mkString("\n"))

--- a/src/main/scala/software/purpledragon/sbt/lock/model/ResolvedArtifact.scala
+++ b/src/main/scala/software/purpledragon/sbt/lock/model/ResolvedArtifact.scala
@@ -16,4 +16,10 @@
 
 package software.purpledragon.sbt.lock.model
 
-final case class ResolvedArtifact(name: String, hash: String)
+import scala.math.Ordered.orderingToOrdered
+
+final case class ResolvedArtifact(name: String, hash: String) extends Ordered[ResolvedArtifact] {
+  override def compare(that: ResolvedArtifact): Int = {
+    (name, hash) compare (that.name, that.hash)
+  }
+}

--- a/src/main/scala/software/purpledragon/sbt/lock/model/ResolvedDependency.scala
+++ b/src/main/scala/software/purpledragon/sbt/lock/model/ResolvedDependency.scala
@@ -16,6 +16,7 @@
 
 package software.purpledragon.sbt.lock.model
 
+import scala.collection.SortedSet
 import scala.math.Ordered.orderingToOrdered
 
 final case class ResolvedDependency(
@@ -23,7 +24,7 @@ final case class ResolvedDependency(
     name: String,
     version: String,
     artifacts: Seq[ResolvedArtifact],
-    configurations: Set[String])
+    configurations: SortedSet[String])
     extends Ordered[ResolvedDependency] {
 
   override def compare(that: ResolvedDependency): Int = {

--- a/src/main/scala/software/purpledragon/sbt/lock/model/ResolvedDependency.scala
+++ b/src/main/scala/software/purpledragon/sbt/lock/model/ResolvedDependency.scala
@@ -23,7 +23,7 @@ final case class ResolvedDependency(
     org: String,
     name: String,
     version: String,
-    artifacts: Seq[ResolvedArtifact],
+    artifacts: SortedSet[ResolvedArtifact],
     configurations: SortedSet[String])
     extends Ordered[ResolvedDependency] {
 

--- a/src/test/scala/software/purpledragon/sbt/lock/model/DependencyLockFileSpec.scala
+++ b/src/test/scala/software/purpledragon/sbt/lock/model/DependencyLockFileSpec.scala
@@ -21,6 +21,8 @@ import java.time.Instant
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
+import scala.collection.SortedSet
+
 class DependencyLockFileSpec extends AnyFlatSpec with Matchers {
   private val EmptyLockFile = DependencyLockFile(1, Instant.now(), Nil, Nil)
   private val TestLockFile = DependencyLockFile(
@@ -33,8 +35,8 @@ class DependencyLockFileSpec extends AnyFlatSpec with Matchers {
         "package-1",
         "1.0.0",
         Seq(ResolvedArtifact("package-1.jar", "hash-1")),
-        Set("test-1")),
-      ResolvedDependency("com.example", "package-2", "1.2.0", Nil, Set("test-2"))
+        SortedSet("test-1")),
+      ResolvedDependency("com.example", "package-2", "1.2.0", Nil, SortedSet("test-2"))
     )
   )
 
@@ -81,7 +83,7 @@ class DependencyLockFileSpec extends AnyFlatSpec with Matchers {
       "package-3",
       "3.0",
       Seq(ResolvedArtifact("package-3.jar", "hash-3")),
-      Set("test-1"))
+      SortedSet("test-1"))
 
     val left = TestLockFile
     val right = left.copy(dependencies = left.dependencies :+ newDependency)
@@ -104,7 +106,7 @@ class DependencyLockFileSpec extends AnyFlatSpec with Matchers {
         "package-1",
         "2.0.0",
         Seq(ResolvedArtifact("package-1.jar", "hash-1a")),
-        Set("test-1", "test-2"))
+        SortedSet("test-1", "test-2"))
     )
 
     left.findChanges(right) shouldBe LockFileDiffers(

--- a/src/test/scala/software/purpledragon/sbt/lock/model/DependencyLockFileSpec.scala
+++ b/src/test/scala/software/purpledragon/sbt/lock/model/DependencyLockFileSpec.scala
@@ -34,9 +34,9 @@ class DependencyLockFileSpec extends AnyFlatSpec with Matchers {
         "com.example",
         "package-1",
         "1.0.0",
-        Seq(ResolvedArtifact("package-1.jar", "hash-1")),
+        SortedSet(ResolvedArtifact("package-1.jar", "hash-1")),
         SortedSet("test-1")),
-      ResolvedDependency("com.example", "package-2", "1.2.0", Nil, SortedSet("test-2"))
+      ResolvedDependency("com.example", "package-2", "1.2.0", SortedSet.empty, SortedSet("test-2"))
     )
   )
 
@@ -82,7 +82,7 @@ class DependencyLockFileSpec extends AnyFlatSpec with Matchers {
       "com.example",
       "package-3",
       "3.0",
-      Seq(ResolvedArtifact("package-3.jar", "hash-3")),
+      SortedSet(ResolvedArtifact("package-3.jar", "hash-3")),
       SortedSet("test-1"))
 
     val left = TestLockFile
@@ -105,7 +105,7 @@ class DependencyLockFileSpec extends AnyFlatSpec with Matchers {
         "com.example",
         "package-1",
         "2.0.0",
-        Seq(ResolvedArtifact("package-1.jar", "hash-1a")),
+        SortedSet(ResolvedArtifact("package-1.jar", "hash-1a")),
         SortedSet("test-1", "test-2"))
     )
 
@@ -120,10 +120,10 @@ class DependencyLockFileSpec extends AnyFlatSpec with Matchers {
           "package-1",
           "1.0.0",
           "2.0.0",
-          Seq(ResolvedArtifact("package-1.jar", "hash-1")),
-          Seq(ResolvedArtifact("package-1.jar", "hash-1a")),
-          Set("test-1"),
-          Set("test-1", "test-2")
+          SortedSet(ResolvedArtifact("package-1.jar", "hash-1")),
+          SortedSet(ResolvedArtifact("package-1.jar", "hash-1a")),
+          SortedSet("test-1"),
+          SortedSet("test-1", "test-2")
         ))
     )
   }

--- a/src/test/scala/software/purpledragon/sbt/lock/model/LockFileStatusSpec.scala
+++ b/src/test/scala/software/purpledragon/sbt/lock/model/LockFileStatusSpec.scala
@@ -19,6 +19,8 @@ package software.purpledragon.sbt.lock.model
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
+import scala.collection.SortedSet
+
 class LockFileStatusSpec extends AnyFlatSpec with Matchers {
   "LockFileMatches.toShortReport" should "output correct message" in {
     LockFileMatches.toShortReport shouldBe "Dependency lock check passed"
@@ -197,9 +199,9 @@ class LockFileStatusSpec extends AnyFlatSpec with Matchers {
       .withConfigurationsChanged(Seq("test1"), Seq("test2", "test3"))
       .withDependencyChanges(
         Seq(
-          testDependency(name = "artifact1", configs = Set("compile")),
-          testDependency(name = "artifact2", version = "1.2", configs = Set("test"))),
-        Seq(testDependency(name = "artifact3", version = "3.1.1", configs = Set("runtime"))),
+          testDependency(name = "artifact1", configs = SortedSet("compile")),
+          testDependency(name = "artifact2", version = "1.2", configs = SortedSet("test"))),
+        Seq(testDependency(name = "artifact3", version = "3.1.1", configs = SortedSet("runtime"))),
         Seq(
           testChangedDependency(
             org = "org.example",
@@ -223,7 +225,7 @@ class LockFileStatusSpec extends AnyFlatSpec with Matchers {
       org: String = "com.example",
       name: String = "artifact",
       version: String = "1.0",
-      configs: Set[String] = Set("compile", "test")): ResolvedDependency = {
+      configs: SortedSet[String] = SortedSet("compile", "test")): ResolvedDependency = {
     ResolvedDependency(org, name, version, Nil, configs)
   }
 

--- a/src/test/scala/software/purpledragon/sbt/lock/model/LockFileStatusSpec.scala
+++ b/src/test/scala/software/purpledragon/sbt/lock/model/LockFileStatusSpec.scala
@@ -129,7 +129,7 @@ class LockFileStatusSpec extends AnyFlatSpec with Matchers {
     val expected =
       """Dependency lock check failed:
         |  1 dependency added:
-        |    com.example:artifact:1.0 (compile,test)""".stripMargin
+        |    com.example:artifact  (compile,test)  1.0""".stripMargin
 
     LockFileMatches.withDependencyChanges(Seq(testDependency()), Nil, Nil).toLongReport shouldBe expected
   }
@@ -138,8 +138,8 @@ class LockFileStatusSpec extends AnyFlatSpec with Matchers {
     val expected =
       """Dependency lock check failed:
         |  2 dependencies removed:
-        |    com.example:artifact:1.0 (compile,test)
-        |    com.example:artifact-2:1.0 (compile,test)""".stripMargin
+        |    com.example:artifact    (compile,test)  1.0
+        |    com.example:artifact-2  (compile,test)  1.0""".stripMargin
 
     LockFileMatches
       .withDependencyChanges(Nil, Seq(testDependency(), testDependency(name = "artifact-2")), Nil)
@@ -150,7 +150,7 @@ class LockFileStatusSpec extends AnyFlatSpec with Matchers {
     val expected =
       """Dependency lock check failed:
         |  1 dependency changed:
-        |    com.example:artifact:[1.0]->[2.0] (compile,test)""".stripMargin
+        |    com.example:artifact  (compile,test)    1.0  -> 2.0""".stripMargin
 
     LockFileMatches.withDependencyChanges(Nil, Nil, Seq(testChangedDependency())).toLongReport shouldBe expected
   }
@@ -159,7 +159,7 @@ class LockFileStatusSpec extends AnyFlatSpec with Matchers {
     val expected =
       """Dependency lock check failed:
         |  1 dependency changed:
-        |    com.example:artifact:1.0 (compile,test)->(compile)""".stripMargin
+        |    com.example:artifact  (compile,test)  -> (compile)  1.0""".stripMargin
 
     LockFileMatches
       .withDependencyChanges(
@@ -173,7 +173,7 @@ class LockFileStatusSpec extends AnyFlatSpec with Matchers {
     val expected =
       """Dependency lock check failed:
         |  1 dependency changed:
-        |    com.example:artifact:[1.0]->[2.0] (compile,test)->(compile)""".stripMargin
+        |    com.example:artifact  (compile,test)  -> (compile)  1.0  -> 2.0""".stripMargin
 
     LockFileMatches
       .withDependencyChanges(Nil, Nil, Seq(testChangedDependency(newConfigurations = SortedSet("compile"))))
@@ -186,14 +186,14 @@ class LockFileStatusSpec extends AnyFlatSpec with Matchers {
         |  1 config added: test1
         |  2 configs removed: test2,test3
         |  2 dependencies added:
-        |    com.example:artifact1:1.0 (compile)
-        |    com.example:artifact2:1.2 (test)
+        |    com.example:artifact1  (compile)  1.0
+        |    com.example:artifact2  (test)     1.2
         |  1 dependency removed:
-        |    com.example:artifact3:3.1.1 (runtime)
+        |    com.example:artifact3  (runtime)  3.1.1
         |  3 dependencies changed:
-        |    org.example:version:[1.0]->[2.0] (compile)
-        |    org.example:configs:1.0 (compile,test)->(compile)
-        |    org.example:both:[1.0]->[2.0] (compile)->(compile,test)""".stripMargin
+        |    org.example:version  (compile)                          1.0  -> 2.0
+        |    org.example:configs  (compile,test)  -> (compile)       1.0
+        |    org.example:both     (compile)       -> (compile,test)  1.0  -> 2.0""".stripMargin
 
     val actual = LockFileMatches
       .withConfigurationsChanged(Seq("test1"), Seq("test2", "test3"))

--- a/src/test/scala/software/purpledragon/sbt/lock/model/LockFileStatusSpec.scala
+++ b/src/test/scala/software/purpledragon/sbt/lock/model/LockFileStatusSpec.scala
@@ -165,7 +165,7 @@ class LockFileStatusSpec extends AnyFlatSpec with Matchers {
       .withDependencyChanges(
         Nil,
         Nil,
-        Seq(testChangedDependency(newVersion = "1.0", newConfigurations = Set("compile"))))
+        Seq(testChangedDependency(newVersion = "1.0", newConfigurations = SortedSet("compile"))))
       .toLongReport shouldBe expected
   }
 
@@ -176,7 +176,7 @@ class LockFileStatusSpec extends AnyFlatSpec with Matchers {
         |    com.example:artifact:[1.0]->[2.0] (compile,test)->(compile)""".stripMargin
 
     LockFileMatches
-      .withDependencyChanges(Nil, Nil, Seq(testChangedDependency(newConfigurations = Set("compile"))))
+      .withDependencyChanges(Nil, Nil, Seq(testChangedDependency(newConfigurations = SortedSet("compile"))))
       .toLongReport shouldBe expected
   }
 
@@ -206,14 +206,14 @@ class LockFileStatusSpec extends AnyFlatSpec with Matchers {
           testChangedDependency(
             org = "org.example",
             name = "version",
-            oldConfigurations = Set("compile"),
-            newConfigurations = Set("compile")),
+            oldConfigurations = SortedSet("compile"),
+            newConfigurations = SortedSet("compile")),
           testChangedDependency(
             org = "org.example",
             name = "configs",
             newVersion = "1.0",
-            newConfigurations = Set("compile")),
-          testChangedDependency(org = "org.example", name = "both", oldConfigurations = Set("compile"))
+            newConfigurations = SortedSet("compile")),
+          testChangedDependency(org = "org.example", name = "both", oldConfigurations = SortedSet("compile"))
         )
       )
       .toLongReport
@@ -226,7 +226,7 @@ class LockFileStatusSpec extends AnyFlatSpec with Matchers {
       name: String = "artifact",
       version: String = "1.0",
       configs: SortedSet[String] = SortedSet("compile", "test")): ResolvedDependency = {
-    ResolvedDependency(org, name, version, Nil, configs)
+    ResolvedDependency(org, name, version, SortedSet.empty, configs)
   }
 
   private def testChangedDependency(
@@ -234,9 +234,17 @@ class LockFileStatusSpec extends AnyFlatSpec with Matchers {
       name: String = "artifact",
       oldVersion: String = "1.0",
       newVersion: String = "2.0",
-      oldConfigurations: Set[String] = Set("compile", "test"),
-      newConfigurations: Set[String] = Set("compile", "test")): ChangedDependency = {
+      oldConfigurations: SortedSet[String] = SortedSet("compile", "test"),
+      newConfigurations: SortedSet[String] = SortedSet("compile", "test")): ChangedDependency = {
 
-    ChangedDependency(org, name, oldVersion, newVersion, Nil, Nil, oldConfigurations, newConfigurations)
+    ChangedDependency(
+      org,
+      name,
+      oldVersion,
+      newVersion,
+      SortedSet.empty,
+      SortedSet.empty,
+      oldConfigurations,
+      newConfigurations)
   }
 }

--- a/src/test/scala/software/purpledragon/sbt/lock/model/LockFileStatusSpec.scala
+++ b/src/test/scala/software/purpledragon/sbt/lock/model/LockFileStatusSpec.scala
@@ -88,6 +88,35 @@ class LockFileStatusSpec extends AnyFlatSpec with Matchers {
     LockFileMatches.withDependencyChanges(Nil, Nil, Seq(testChangedDependency())).toShortReport shouldBe expected
   }
 
+  it should "render 2 dependency artifacts changed" in {
+    val expected =
+      """Dependency lock check failed:
+        |  2 dependency artifacts changed""".stripMargin
+
+    LockFileMatches
+      .withDependencyChanges(
+        Nil,
+        Nil,
+        Seq(
+          testChangedDependencyArtifacts(
+            "dependency-1",
+            "1.1",
+            oldArtifacts = Seq(ResolvedArtifact("artifact-2.jar", "sha1:07c10d545325e3a6e72e06381afe469fd40eb701")),
+            newArtifacts = Seq(ResolvedArtifact("artifact-1.jar", "sha1:2b8b815229aa8a61e483fb4ba0588b8b6c491890"))
+          ),
+          testChangedDependencyArtifacts(
+            "dependency-2",
+            "1.1.2",
+            oldArtifacts = Seq(
+              ResolvedArtifact("artifact-a.jar", "sha1:07c10d545325e3a6e72e06381afe469fd40eb701"),
+              ResolvedArtifact("artifact-b.jar", "sha1:cfa4f316351a91bfd95cb0644c6a2c95f52db1fc")
+            )
+          )
+        )
+      )
+      .toShortReport shouldBe expected
+  }
+
   it should "render configs and dependencies changed" in {
     val expected =
       """Dependency lock check failed:

--- a/src/test/scala/software/purpledragon/sbt/lock/model/LockFileStatusSpec.scala
+++ b/src/test/scala/software/purpledragon/sbt/lock/model/LockFileStatusSpec.scala
@@ -180,6 +180,35 @@ class LockFileStatusSpec extends AnyFlatSpec with Matchers {
       .toLongReport shouldBe expected
   }
 
+  it should "render 2 dependency artifacts changed" in {
+    val expected =
+      """Dependency lock check failed:
+        |  2 dependency artifacts changed""".stripMargin
+
+    LockFileMatches
+      .withDependencyChanges(
+        Nil,
+        Nil,
+        Seq(
+          testChangedDependencyArtifacts(
+            "dependency-1",
+            "1.1",
+            oldArtifacts = Seq(ResolvedArtifact("artifact-2.jar", "sha1:07c10d545325e3a6e72e06381afe469fd40eb701")),
+            newArtifacts = Seq(ResolvedArtifact("artifact-1.jar", "sha1:2b8b815229aa8a61e483fb4ba0588b8b6c491890"))
+          ),
+          testChangedDependencyArtifacts(
+            "dependency-2",
+            "1.1.2",
+            oldArtifacts = Seq(
+              ResolvedArtifact("artifact-a.jar", "sha1:07c10d545325e3a6e72e06381afe469fd40eb701"),
+              ResolvedArtifact("artifact-b.jar", "sha1:cfa4f316351a91bfd95cb0644c6a2c95f52db1fc")
+            )
+          )
+        )
+      )
+      .toLongReport shouldBe expected
+  }
+
   it should "render lots of changes" in {
     val expected =
       """Dependency lock check failed:
@@ -246,5 +275,24 @@ class LockFileStatusSpec extends AnyFlatSpec with Matchers {
       SortedSet.empty,
       oldConfigurations,
       newConfigurations)
+  }
+
+  private def testChangedDependencyArtifacts(
+      name: String,
+      version: String,
+      org: String = "com.example",
+      oldArtifacts: Seq[ResolvedArtifact] = Nil,
+      newArtifacts: Seq[ResolvedArtifact] = Nil): ChangedDependency = {
+
+    ChangedDependency(
+      org,
+      name,
+      version,
+      version,
+      oldArtifacts.to[SortedSet],
+      newArtifacts.to[SortedSet],
+      SortedSet("compile"),
+      SortedSet("compile")
+    )
   }
 }


### PR DESCRIPTION
This reworks the output of the long error report to make items more tabular to ease reading.

### Before
```text
Dependency lock check failed:
  1 config added: test1
  2 configs removed: test2,test3
  2 dependencies added:
    com.example:artifact1:1.0 (compile)
    com.example:artifact2:1.2 (test)
  1 dependency removed:
    com.example:artifact3:3.1.1 (runtime)
  3 dependencies changed:
    org.example:version:[1.0]->[2.0] (compile)
    org.example:configs:1.0 (compile,test)->(compile)
    org.example:both:[1.0]->[2.0] (compile)->(compile,test)
```
### After
```text
Dependency lock check failed:
  1 config added: test1
  2 configs removed: test2,test3
  2 dependencies added:
    com.example:artifact1  (compile)  1.0
    com.example:artifact2  (test)     1.2
  1 dependency removed:
    com.example:artifact3  (runtime)  3.1.1
  3 dependencies changed:
    org.example:version  (compile)                          1.0  -> 2.0
    org.example:configs  (compile,test)  -> (compile)       1.0
    org.example:both     (compile)       -> (compile,test)  1.0  -> 2.0
```