### PR TITLE
Documentation tweaks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,5 @@
+name: ci
+
 on:
   push:
     branches:

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # sbt-dependency-lock 
 
-[![Build Status](https://img.shields.io/github/workflow/status/stringbean/sbt-dependency-lock/ci)](https://github.com/stringbean/sbt-dependency-lock/actions/workflows/ci.yml)
+[![Build Status](https://img.shields.io/github/workflow/status/stringbean/sbt-dependency-lock/ci)(https://github.com/stringbean/sbt-dependency-lock/actions/workflows/ci.yml)
 [![Codacy grade](https://img.shields.io/codacy/grade/d45ca406c90c45c88a3a317563bc3302?label=codacy)](https://codacy.com/app/stringbean/sbt-dependency-lock)
 [![Known Vulnerabilities](https://snyk.io/test/github/stringbean/sbt-dependency-lock/badge.svg?targetFile=build.sbt)](https://snyk.io/test/github/stringbean/sbt-dependency-lock?targetFile=build.sbt)
-![Maven Central](https://img.shields.io/maven-central/v/software.purpledragon/sbt-dependency-lock_2.12_1.0?label=sbt%201.x) 
+![Maven Central](https://maven-badges.herokuapp.com/maven-central/software.purpledragon/sbt-dependency-lock/badge.svg?style=flat) 
 [![GitHub Discussions](https://img.shields.io/github/discussions/stringbean/sbt-dependency-lock)](https://github.com/stringbean/sbt-dependency-lock/discussions)
 
 An sbt plugin to create a dependency lockfile similar to `package-lock.json` for npm or `Gemfile.lock` for RubyGems.

--- a/src/main/paradox/file-formats/version-1.md
+++ b/src/main/paradox/file-formats/version-1.md
@@ -1,11 +1,5 @@
 # Version 1
 
-@@@warning
-This version of the lockfile has not been finalised and may change as features are added or bugs resolved.
-
-The format will be finalised in version 1.0.0.
-@@@
-
 * **Added in:** 0.1.0
 * **Removed in:** _N/A_
 

--- a/src/main/paradox/index.md
+++ b/src/main/paradox/index.md
@@ -11,6 +11,24 @@ cause a snowball effect of dozens of updated transitive dependencies.
 This plugin generates a lockfile based on the current project dependencies that can be checked into source control and
 can be checked to see what dependencies have changed. 
 
+## Alternatives
+
+### sbt-lock
+
+[sbt-lock](https://github.com/tkawachi/sbt-lock) is an sbt plugin that generates lockfiles to control the resolved
+dependency versions. When enabled it will generate a `lock.sbt` file that sets `Compile / dependencyOverrides` to the
+currently resolved versions, any further changes to the dependencies will be overridden until the lockfile is
+regenerated.
+
+While `sbt-lock` is good at fixing the versions that sbt will use for future builds it is weak at showing what
+dependencies have changed. Until the lockfile is 'unlocked' any dependency changes you make to `build.sbt` will be
+ignored; this forces you to 'unlock', update the dependencies, 'lock' again and then diff the lockfile to see what has
+changed.
+
+The approach taken by `sbt-dependency-lock` is to allow changes to be made to the dependencies, warn you that the
+dependencies have changed and generate a report showing the changes. Keeping the lockfile up to date can be enforced
+using a lockfile check in a CI pipeline.
+
 @@@ index
 * [Getting Started](getting-started.md)
 * [Settings](settings.md)


### PR DESCRIPTION
Removes the warning about v1 lockfile format not being finalised and adds a section about `sbt-lock`.