### PR TITLE
Sort dependencies in error reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,10 @@ A mismatch between the lockfile and current dependencies will generate an error 
 ```text
 [error] (dependencyLockCheck) Dependency lock check failed:
 [error]   3 dependencies changed:
-[error]     org.scala-lang.modules:scala-xml_2.12:[1.2.0]->[1.1.0] (test)
-[error]     org.scalactic:scalactic_2.12:[3.0.8]->[3.0.7] (test)
-[error]     org.scalatest:scalatest_2.12:[3.0.8]->[3.0.7] (test)
+[error]     org.apache.commons:commons-lang3       (test)  -> (compile,test)  3.9 
+[error]     org.scala-lang.modules:scala-xml_2.12  (test)                     1.2.0  -> 1.1.0 
+[error]     org.scalactic:scalactic_2.12           (test)                     3.0.8  -> 3.0.7 
+[error]     org.scalatest:scalatest_2.12           (test)                     3.0.8  -> 3.0.7 
 ```
 
 See the [docs](https://stringbean.github.io/sbt-dependency-lock) for further information on how the plugin works.

--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,7 @@ libraryDependencies ++= Seq(
 ).map(_ % circeVersion)
 
 libraryDependencies ++= Seq(
-  "software.purpledragon" %% "text-utils" % "1.3.0",
+  "software.purpledragon" %% "text-utils" % "1.3.1",
   "org.scalatest"         %% "scalatest"  % "3.2.9" % Test
 )
 

--- a/src/main/paradox/getting-started.md
+++ b/src/main/paradox/getting-started.md
@@ -49,10 +49,10 @@ A mismatch between the lockfile and current dependencies will generate an error 
 ```text
 [error] (dependencyLockCheck) Dependency lock check failed:
 [error]   3 dependencies changed:
-[error]     org.apache.commons:commons-lang3:3.9 (test)->(compile,test)
-[error]     org.scala-lang.modules:scala-xml_2.12:[1.2.0]->[1.1.0] (test)
-[error]     org.scalactic:scalactic_2.12:[3.0.8]->[3.0.7] (test)
-[error]     org.scalatest:scalatest_2.12:[3.0.8]->[3.0.7] (test)
+[error]     org.apache.commons:commons-lang3       (test)  -> (compile,test)  3.9 
+[error]     org.scala-lang.modules:scala-xml_2.12  (test)                     1.2.0  -> 1.1.0 
+[error]     org.scalactic:scalactic_2.12           (test)                     3.0.8  -> 3.0.7 
+[error]     org.scalatest:scalatest_2.12           (test)                     3.0.8  -> 3.0.7 
 ```
 
 The error report is broken down into a number of sections:
@@ -68,18 +68,18 @@ The error report is broken down into a number of sections:
 3. Dependencies added:
     ```text
     2 dependencies added:
-      com.example:artifact1:1.0 (compile)
-      com.example:artifact2:1.2 (test)
+      com.example:artifact1  (compile)  1.0
+      com.example:artifact2  (test)     1.2
     ```
 4. Dependencies removed:
     ```text
     1 dependency removed:
-      com.example:artifact3:3.1.1 (runtime)
+      com.example:artifact3  (runtime)  3.1.1
     ```
 5. Changed dependencies:
     ```text
     3 dependencies changed:
-      org.example:version:[1.0]->[2.0] (compile)
-      org.example:configs:1.0 (compile,test)->(compile)
-      org.example:both:[1.0]->[2.0] (compile)->(compile,test)
+      org.example:both     (compile)       -> (compile,test)  1.0  -> 2.0
+      org.example:configs  (compile,test)  -> (compile)       1.0
+      org.example:version  (compile)                          1.0  -> 2.0
     ```

--- a/src/main/scala/software/purpledragon/sbt/lock/model/LockFileStatus.scala
+++ b/src/main/scala/software/purpledragon/sbt/lock/model/LockFileStatus.scala
@@ -17,7 +17,7 @@
 package software.purpledragon.sbt.lock.model
 
 import software.purpledragon.sbt.lock.util.MessageUtil
-import software.purpledragon.text.TableFormatter
+import software.purpledragon.text.SortedTableFormatter
 
 import scala.collection.mutable
 
@@ -116,8 +116,7 @@ final case class LockFileDiffers(
     }
 
     def dumpDependencies(dependencies: Seq[ResolvedDependency]): String = {
-      val table =
-        new TableFormatter(None, prefix = "    ", stripTrailingNewline = true)
+      val table = new SortedTableFormatter(None, prefix = "    ", stripTrailingNewline = true)
 
       dependencies foreach { dep =>
         table.addRow(s"${dep.org}:${dep.name}", s"(${dep.configurations.mkString(",")})", dep.version)
@@ -141,7 +140,7 @@ final case class LockFileDiffers(
     }
 
     def dumpChanges(changes: Seq[ChangedDependency]): String = {
-      val table = new TableFormatter(None, prefix = "    ", stripTrailingNewline = true)
+      val table = new SortedTableFormatter(None, prefix = "    ", stripTrailingNewline = true)
 
       changes foreach { change =>
         table.addRow(

--- a/src/test/scala/software/purpledragon/sbt/lock/model/LockFileStatusSpec.scala
+++ b/src/test/scala/software/purpledragon/sbt/lock/model/LockFileStatusSpec.scala
@@ -238,6 +238,45 @@ class LockFileStatusSpec extends AnyFlatSpec with Matchers {
       .toLongReport shouldBe expected
   }
 
+  it should "sort dependencies" in {
+    val expected =
+      """Dependency lock check failed:
+        |  3 dependencies added:
+        |    com.example:added-2  (compile,test)  1.0
+        |    com.example:added-3  (compile,test)  1.0
+        |    net.example:added-1  (compile,test)  1.0
+        |  3 dependencies removed:
+        |    com.example:removed-1  (compile,test)  1.0
+        |    com.example:removed-2  (compile,test)  1.0
+        |    com.example:removed-3  (compile,test)  1.0
+        |  3 dependencies changed:
+        |    com.example:changed-2  (compile,test)    1.0  -> 1.3
+        |    com.example:changed-3  (compile,test)    1.0  -> 1.2
+        |    net.example:changed-1  (compile,test)    1.0  -> 1.0.1""".stripMargin
+
+    val actual = LockFileMatches
+      .withDependencyChanges(
+        Seq(
+          testDependency(name = "added-3"),
+          testDependency(name = "added-2"),
+          testDependency(org = "net.example", name = "added-1")
+        ),
+        Seq(
+          testDependency(name = "removed-1"),
+          testDependency(name = "removed-3"),
+          testDependency(name = "removed-2")
+        ),
+        Seq(
+          testChangedDependency(name = "changed-3", newVersion = "1.2"),
+          testChangedDependency(name = "changed-2", newVersion = "1.3"),
+          testChangedDependency(org = "net.example", name = "changed-1", newVersion = "1.0.1")
+        )
+      )
+      .toLongReport
+
+    actual shouldBe expected
+  }
+
   it should "render lots of changes" in {
     val expected =
       """Dependency lock check failed:
@@ -249,9 +288,9 @@ class LockFileStatusSpec extends AnyFlatSpec with Matchers {
         |  1 dependency removed:
         |    com.example:artifact3  (runtime)  3.1.1
         |  3 dependencies changed:
-        |    org.example:version  (compile)                          1.0  -> 2.0
+        |    org.example:both     (compile)       -> (compile,test)  1.0  -> 2.0
         |    org.example:configs  (compile,test)  -> (compile)       1.0
-        |    org.example:both     (compile)       -> (compile,test)  1.0  -> 2.0""".stripMargin
+        |    org.example:version  (compile)                          1.0  -> 2.0""".stripMargin
 
     val actual = LockFileMatches
       .withConfigurationsChanged(Seq("test1"), Seq("test2", "test3"))


### PR DESCRIPTION
This adds an alpha sort on the dependency moduleID in the long report. This makes it easier for humans to read and helps make the output more stable (results are not returned in the order that they were resolved).

Before:
```text
Dependency lock check failed:
  3 dependencies changed:
    org.example:version  (compile)                          1.0  -> 2.0
    org.example:both     (compile)       -> (compile,test)  1.0  -> 2.0
    org.example:configs  (compile,test)  -> (compile)       1.0
```

After:
```text
Dependency lock check failed:
  3 dependencies changed:
    org.example:both     (compile)       -> (compile,test)  1.0  -> 2.0
    org.example:configs  (compile,test)  -> (compile)       1.0
    org.example:version  (compile)                          1.0  -> 2.0
```