### PR TITLE
Add option for automatically updating lockfile

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,7 @@ libraryDependencies ++= Seq(
 
 libraryDependencies ++= Seq(
   "software.purpledragon" %% "text-utils" % "1.3.1",
-  "org.scalatest"         %% "scalatest"  % "3.2.9" % Test
+  "org.scalatest"         %% "scalatest"  % "3.2.12" % Test
 )
 
 organizationName := "Michael Stringer"
@@ -30,7 +30,7 @@ scriptedLaunchOpts := { scriptedLaunchOpts.value ++
   Seq("-Xmx1024M", "-Dplugin.version=" + version.value)
 }
 
-ThisBuild / scapegoatVersion  := "1.4.9"
+ThisBuild / scapegoatVersion  := "1.4.11"
 
 developers := List(
   Developer("stringbean", "Michael Stringer", "@the_stringbean", url("https://github.com/stringbean"))

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.3
+sbt.version=1.6.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,11 +1,11 @@
 // publishing
 addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.1.2")
-addSbtPlugin("com.github.sbt" % "sbt-release" % "1.0.15")
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.7")
+addSbtPlugin("com.github.sbt" % "sbt-release" % "1.1.0")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.11")
 
 // code style
-addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.6.0")
-addSbtPlugin("com.sksamuel.scapegoat" %% "sbt-scapegoat" % "1.1.0")
+addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.7.0")
+addSbtPlugin("com.sksamuel.scapegoat" %% "sbt-scapegoat" % "1.1.1")
 
 // documentation
 addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "1.4.1")

--- a/src/main/paradox/settings.md
+++ b/src/main/paradox/settings.md
@@ -19,3 +19,5 @@ The different levels of checking available are:
 * `CheckDisabled`: no checks will be performed after `update`s.
 * `WarnOnError`: a check will be performed after `update`s, and a warning printed if there are any changes.
 * `FailOnError`: a check will be performed after `update`s, and the build will fail if there are any changes.
+* `AutoUpdate`: a check will be performed after `update`s, and the lockfile will be automatically updated if there are
+  any changes.

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -7,6 +7,7 @@ lock.status.failed.long=Dependency lock check failed:\n{0}
 
 update.status.warning=Dependency lockfile is outdated - please run `dependencyLockCheck` for details
 update.status.error=Dependency lockfile is outdated
+update.status.auto=Dependency lockfile is outdated - automatically updating
 
 # lockfile short status - configurations ======================================
 lock.status.configs.info=\ \ {0} added and {1} removed

--- a/src/main/scala/software/purpledragon/sbt/lock/DependencyLockPlugin.scala
+++ b/src/main/scala/software/purpledragon/sbt/lock/DependencyLockPlugin.scala
@@ -16,8 +16,8 @@
 
 package software.purpledragon.sbt.lock
 
-import sbt.Keys._
 import sbt._
+import sbt.Keys._
 import sbt.internal.util.ManagedLogger
 import software.purpledragon.sbt.lock.DependencyLockUpdateMode._
 import software.purpledragon.sbt.lock.model.{DependencyLockFile, LockFileMatches}
@@ -100,6 +100,12 @@ object DependencyLockPlugin extends AutoPlugin {
               case (_, FailOnError) =>
                 logger.error(MessageUtil.formatMessage("update.status.error"))
                 sys.error(changes.toLongReport)
+              case (_, AutoUpdate) =>
+                logger.warn(MessageUtil.formatMessage("update.status.auto"))
+
+                // rewrite the lockfile
+                val dest = dependencyLockFile.value
+                DependencyLockIO.writeLockFile(updatedFile, dest)
 
               case _ =>
               // scenario shouldn't happen - failed check, but we're not checking...

--- a/src/main/scala/software/purpledragon/sbt/lock/DependencyLockUpdateMode.scala
+++ b/src/main/scala/software/purpledragon/sbt/lock/DependencyLockUpdateMode.scala
@@ -19,5 +19,5 @@ package software.purpledragon.sbt.lock
 object DependencyLockUpdateMode extends Enumeration {
   type DependencyLockUpdateMode = Value
 
-  val CheckDisabled, WarnOnError, FailOnError = Value
+  val CheckDisabled, WarnOnError, FailOnError, AutoUpdate = Value
 }

--- a/src/sbt-test/update/auto-update-differences/build.sbt
+++ b/src/sbt-test/update/auto-update-differences/build.sbt
@@ -1,0 +1,33 @@
+scalaVersion := "2.12.10"
+
+libraryDependencies ++= Seq(
+  "org.apache.commons" % "commons-lang3" % "3.9",
+  // lockfile has 3.0.8
+  "org.scalatest"     %% "scalatest"     % "3.0.7" % Test
+)
+
+dependencyLockAutoCheck := DependencyLockUpdateMode.AutoUpdate
+
+val checkLog      = taskKey[Unit]("checks the contents of the log")
+val checkLockfile = taskKey[Unit]("checks the contents of the lockfile")
+
+checkLog := {
+  val lastLog = BuiltinCommands.lastLogFile(state.value).get
+  val last    = IO.read(lastLog)
+
+  if (!last.contains("Dependency lockfile is outdated")) {
+    sys.error("check did not contain warning")
+  }
+}
+
+checkLockfile := {
+  val lockfile = dependencyLockRead.value.getOrElse(sys.error("Failed to read updated lockfile"))
+
+  val scalatest = lockfile.dependencies
+    .find(dep => dep.org == "org.scalatest" && dep.name == "scalatest_2.12")
+    .getOrElse(sys.error("Failed to find scalatest dependency"))
+
+  if (scalatest.version != "3.0.7") {
+    sys.error("Updated lockfile had incorrect scalatest version")
+  }
+}

--- a/src/sbt-test/update/auto-update-differences/build.sbt.lock
+++ b/src/sbt-test/update/auto-update-differences/build.sbt.lock
@@ -1,0 +1,101 @@
+{
+  "lockVersion" : 1,
+  "timestamp" : "2019-11-21T18:42:01.200Z",
+  "configurations" : [
+    "compile",
+    "optional",
+    "provided",
+    "runtime",
+    "test"
+  ],
+  "dependencies" : [
+    {
+      "org" : "org.apache.commons",
+      "name" : "commons-lang3",
+      "version" : "3.9",
+      "artifacts" : [
+        {
+          "name" : "commons-lang3.jar",
+          "hash" : "sha1:0122c7cee69b53ed4a7681c03d4ee4c0e2765da5"
+        }
+      ],
+      "configurations" : [
+        "test",
+        "compile",
+        "runtime"
+      ]
+    },
+    {
+      "org" : "org.scala-lang",
+      "name" : "scala-library",
+      "version" : "2.12.10",
+      "artifacts" : [
+        {
+          "name" : "scala-library.jar",
+          "hash" : "sha1:3509860bc2e5b3da001ed45aca94ffbe5694dbda"
+        }
+      ],
+      "configurations" : [
+        "test",
+        "compile",
+        "runtime"
+      ]
+    },
+    {
+      "org" : "org.scala-lang",
+      "name" : "scala-reflect",
+      "version" : "2.12.10",
+      "artifacts" : [
+        {
+          "name" : "scala-reflect.jar",
+          "hash" : "sha1:14cb7beb516cd8e07716133668c427792122c926"
+        }
+      ],
+      "configurations" : [
+        "test"
+      ]
+    },
+    {
+      "org" : "org.scala-lang.modules",
+      "name" : "scala-xml_2.12",
+      "version" : "1.2.0",
+      "artifacts" : [
+        {
+          "name" : "scala-xml_2.12.jar",
+          "hash" : "sha1:5d38ac30beb8420dd395c0af447ba412158965e6"
+        }
+      ],
+      "configurations" : [
+        "test"
+      ]
+    },
+    {
+      "org" : "org.scalactic",
+      "name" : "scalactic_2.12",
+      "version" : "3.0.8",
+      "artifacts" : [
+        {
+          "name" : "scalactic_2.12.jar",
+          "hash" : "sha1:b50559dfc4a691c1089f9c8812e1d6fd17f80277"
+        }
+      ],
+      "configurations" : [
+        "test"
+      ]
+    },
+    {
+      "org" : "org.scalatest",
+      "name" : "scalatest_2.12",
+      "version" : "3.0.8",
+      "artifacts" : [
+        {
+          "name" : "scalatest_2.12.jar",
+          "hash" : "sha1:8493ffa579676977b810a7a9fdc23af9d3c8af7f"
+        }
+      ],
+      "configurations" : [
+        "test"
+      ]
+    }
+  ]
+}

--- a/src/sbt-test/update/auto-update-differences/project/plugins.sbt
+++ b/src/sbt-test/update/auto-update-differences/project/plugins.sbt
@@ -1,0 +1,7 @@
+{
+  val pluginVersion = System.getProperty("plugin.version")
+  if (pluginVersion == null)
+    throw new RuntimeException("""|The system property 'plugin.version' is not defined.
+                                  |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+  else addSbtPlugin("software.purpledragon" % "sbt-dependency-lock" % pluginVersion)
+}

--- a/src/sbt-test/update/auto-update-differences/test
+++ b/src/sbt-test/update/auto-update-differences/test
@@ -1,0 +1,3 @@
+> update
+> checkLog
+> checkLockfile

--- a/src/sbt-test/update/auto-update-same/build.sbt
+++ b/src/sbt-test/update/auto-update-same/build.sbt
@@ -1,0 +1,19 @@
+scalaVersion := "2.12.10"
+
+libraryDependencies ++= Seq(
+  "org.apache.commons"  %  "commons-lang3"  % "3.9",
+  "org.scalatest"       %% "scalatest"      % "3.0.8"   % Test,
+)
+
+dependencyLockAutoCheck := DependencyLockUpdateMode.AutoUpdate
+
+val checkLog = taskKey[Unit]("checks the contents of the log")
+
+checkLog := {
+  val lastLog = BuiltinCommands.lastLogFile(state.value).get
+  val last = IO.read(lastLog)
+
+  if (last.contains("Dependency lockfile is outdated")) {
+    sys.error("check contained warning")
+  }
+}

--- a/src/sbt-test/update/auto-update-same/build.sbt.lock
+++ b/src/sbt-test/update/auto-update-same/build.sbt.lock
@@ -1,0 +1,101 @@
+{
+  "lockVersion" : 1,
+  "timestamp" : "2019-11-21T18:42:01.200Z",
+  "configurations" : [
+    "compile",
+    "optional",
+    "provided",
+    "runtime",
+    "test"
+  ],
+  "dependencies" : [
+    {
+      "org" : "org.apache.commons",
+      "name" : "commons-lang3",
+      "version" : "3.9",
+      "artifacts" : [
+        {
+          "name" : "commons-lang3.jar",
+          "hash" : "sha1:0122c7cee69b53ed4a7681c03d4ee4c0e2765da5"
+        }
+      ],
+      "configurations" : [
+        "test",
+        "compile",
+        "runtime"
+      ]
+    },
+    {
+      "org" : "org.scala-lang",
+      "name" : "scala-library",
+      "version" : "2.12.10",
+      "artifacts" : [
+        {
+          "name" : "scala-library.jar",
+          "hash" : "sha1:3509860bc2e5b3da001ed45aca94ffbe5694dbda"
+        }
+      ],
+      "configurations" : [
+        "test",
+        "compile",
+        "runtime"
+      ]
+    },
+    {
+      "org" : "org.scala-lang",
+      "name" : "scala-reflect",
+      "version" : "2.12.10",
+      "artifacts" : [
+        {
+          "name" : "scala-reflect.jar",
+          "hash" : "sha1:14cb7beb516cd8e07716133668c427792122c926"
+        }
+      ],
+      "configurations" : [
+        "test"
+      ]
+    },
+    {
+      "org" : "org.scala-lang.modules",
+      "name" : "scala-xml_2.12",
+      "version" : "1.2.0",
+      "artifacts" : [
+        {
+          "name" : "scala-xml_2.12.jar",
+          "hash" : "sha1:5d38ac30beb8420dd395c0af447ba412158965e6"
+        }
+      ],
+      "configurations" : [
+        "test"
+      ]
+    },
+    {
+      "org" : "org.scalactic",
+      "name" : "scalactic_2.12",
+      "version" : "3.0.8",
+      "artifacts" : [
+        {
+          "name" : "scalactic_2.12.jar",
+          "hash" : "sha1:b50559dfc4a691c1089f9c8812e1d6fd17f80277"
+        }
+      ],
+      "configurations" : [
+        "test"
+      ]
+    },
+    {
+      "org" : "org.scalatest",
+      "name" : "scalatest_2.12",
+      "version" : "3.0.8",
+      "artifacts" : [
+        {
+          "name" : "scalatest_2.12.jar",
+          "hash" : "sha1:8493ffa579676977b810a7a9fdc23af9d3c8af7f"
+        }
+      ],
+      "configurations" : [
+        "test"
+      ]
+    }
+  ]
+}

--- a/src/sbt-test/update/auto-update-same/project/plugins.sbt
+++ b/src/sbt-test/update/auto-update-same/project/plugins.sbt
@@ -1,0 +1,7 @@
+{
+  val pluginVersion = System.getProperty("plugin.version")
+  if (pluginVersion == null)
+    throw new RuntimeException("""|The system property 'plugin.version' is not defined.
+                                  |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+  else addSbtPlugin("software.purpledragon" % "sbt-dependency-lock" % pluginVersion)
+}

--- a/src/sbt-test/update/auto-update-same/test
+++ b/src/sbt-test/update/auto-update-same/test
@@ -1,0 +1,2 @@
+> update
+> checkLog


### PR DESCRIPTION
This adds another option to `dependencyLockAutoCheck` called `AutoUpdate` that will automatically run `dependencyLockWrite` if a change in dependencies has been detected.

While this isn't a recommended way to using the plugin it has benefits for some users.