### PR TITLE
Add ability to filter configurations

### DIFF
--- a/src/main/paradox/settings.md
+++ b/src/main/paradox/settings.md
@@ -27,3 +27,9 @@ The different levels of checking available are:
 * **Description:** Excludes the specified dependencies from the lockfile.
 * **Accepts:** `sbt.librarymanagement.ModuleFilter`
 * **Default:** `DependencyFilter.fnToModuleFilter(_ => false)` (no exclusions)
+
+### dependencyLockConfigurationFilter
+
+* **Description:** Excludes the specified configurations from the lockfile.
+* **Accepts:** `sbt.librarymanagement.ConfigurationFilter`
+* **Default:** `DependencyFilter.fnToConfigurationFilter(_ => false)` (no exclusions)

--- a/src/sbt-test/dependencyLockCheck/pass-with-config-exclusion/build.sbt
+++ b/src/sbt-test/dependencyLockCheck/pass-with-config-exclusion/build.sbt
@@ -1,0 +1,9 @@
+scalaVersion := "2.12.10"
+
+libraryDependencies ++= Seq(
+  "org.apache.commons"  %  "commons-lang3"  % "3.9",
+  "org.scalatest"       %% "scalatest"      % "3.0.8"   % Test,
+)
+
+// One ineffective filter and one for the Test scope.
+dependencyLockConfigurationFilter := configurationFilter(name = "fake") | configurationFilter(name = "test")

--- a/src/sbt-test/dependencyLockCheck/pass-with-config-exclusion/build.sbt.lock
+++ b/src/sbt-test/dependencyLockCheck/pass-with-config-exclusion/build.sbt.lock
@@ -1,0 +1,42 @@
+{
+  "lockVersion" : 1,
+  "timestamp" : "2022-08-11T18:02:07.891395Z",
+  "configurations" : [
+    "compile",
+    "optional",
+    "provided",
+    "runtime"
+  ],
+  "dependencies" : [
+    {
+      "org" : "org.apache.commons",
+      "name" : "commons-lang3",
+      "version" : "3.9",
+      "artifacts" : [
+        {
+          "name" : "commons-lang3.jar",
+          "hash" : "sha1:0122c7cee69b53ed4a7681c03d4ee4c0e2765da5"
+        }
+      ],
+      "configurations" : [
+        "compile",
+        "runtime"
+      ]
+    },
+    {
+      "org" : "org.scala-lang",
+      "name" : "scala-library",
+      "version" : "2.12.10",
+      "artifacts" : [
+        {
+          "name" : "scala-library.jar",
+          "hash" : "sha1:3509860bc2e5b3da001ed45aca94ffbe5694dbda"
+        }
+      ],
+      "configurations" : [
+        "compile",
+        "runtime"
+      ]
+    }
+  ]
+}

--- a/src/sbt-test/dependencyLockCheck/pass-with-config-exclusion/project/build.properties
+++ b/src/sbt-test/dependencyLockCheck/pass-with-config-exclusion/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.7.1

--- a/src/sbt-test/dependencyLockCheck/pass-with-config-exclusion/project/plugins.sbt
+++ b/src/sbt-test/dependencyLockCheck/pass-with-config-exclusion/project/plugins.sbt
@@ -1,0 +1,7 @@
+{
+  val pluginVersion = System.getProperty("plugin.version")
+  if (pluginVersion == null)
+    throw new RuntimeException("""|The system property 'plugin.version' is not defined.
+                                  |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+  else addSbtPlugin("software.purpledragon" % "sbt-dependency-lock" % pluginVersion)
+}

--- a/src/sbt-test/dependencyLockCheck/pass-with-config-exclusion/test
+++ b/src/sbt-test/dependencyLockCheck/pass-with-config-exclusion/test
@@ -1,0 +1,1 @@
+> dependencyLockCheck

--- a/src/sbt-test/dependencyLockWrite/unchanged-with-config-exclusion/build.sbt
+++ b/src/sbt-test/dependencyLockWrite/unchanged-with-config-exclusion/build.sbt
@@ -1,0 +1,9 @@
+scalaVersion := "2.12.10"
+
+libraryDependencies ++= Seq(
+  "org.apache.commons"  %  "commons-lang3"  % "3.9",
+  "org.scalatest"       %% "scalatest"      % "3.0.8"   % Test,
+)
+
+// One ineffective filter and one for the Test scope.
+dependencyLockConfigurationFilter := configurationFilter(name = "fake") | configurationFilter(name = "test")

--- a/src/sbt-test/dependencyLockWrite/unchanged-with-config-exclusion/build.sbt.lock
+++ b/src/sbt-test/dependencyLockWrite/unchanged-with-config-exclusion/build.sbt.lock
@@ -1,0 +1,42 @@
+{
+  "lockVersion" : 1,
+  "timestamp" : "2022-08-11T18:02:07.891395Z",
+  "configurations" : [
+    "compile",
+    "optional",
+    "provided",
+    "runtime"
+  ],
+  "dependencies" : [
+    {
+      "org" : "org.apache.commons",
+      "name" : "commons-lang3",
+      "version" : "3.9",
+      "artifacts" : [
+        {
+          "name" : "commons-lang3.jar",
+          "hash" : "sha1:0122c7cee69b53ed4a7681c03d4ee4c0e2765da5"
+        }
+      ],
+      "configurations" : [
+        "compile",
+        "runtime"
+      ]
+    },
+    {
+      "org" : "org.scala-lang",
+      "name" : "scala-library",
+      "version" : "2.12.10",
+      "artifacts" : [
+        {
+          "name" : "scala-library.jar",
+          "hash" : "sha1:3509860bc2e5b3da001ed45aca94ffbe5694dbda"
+        }
+      ],
+      "configurations" : [
+        "compile",
+        "runtime"
+      ]
+    }
+  ]
+}

--- a/src/sbt-test/dependencyLockWrite/unchanged-with-config-exclusion/build.sbt.lock.orig
+++ b/src/sbt-test/dependencyLockWrite/unchanged-with-config-exclusion/build.sbt.lock.orig
@@ -1,0 +1,42 @@
+{
+  "lockVersion" : 1,
+  "timestamp" : "2022-08-11T18:02:07.891395Z",
+  "configurations" : [
+    "compile",
+    "optional",
+    "provided",
+    "runtime"
+  ],
+  "dependencies" : [
+    {
+      "org" : "org.apache.commons",
+      "name" : "commons-lang3",
+      "version" : "3.9",
+      "artifacts" : [
+        {
+          "name" : "commons-lang3.jar",
+          "hash" : "sha1:0122c7cee69b53ed4a7681c03d4ee4c0e2765da5"
+        }
+      ],
+      "configurations" : [
+        "compile",
+        "runtime"
+      ]
+    },
+    {
+      "org" : "org.scala-lang",
+      "name" : "scala-library",
+      "version" : "2.12.10",
+      "artifacts" : [
+        {
+          "name" : "scala-library.jar",
+          "hash" : "sha1:3509860bc2e5b3da001ed45aca94ffbe5694dbda"
+        }
+      ],
+      "configurations" : [
+        "compile",
+        "runtime"
+      ]
+    }
+  ]
+}

--- a/src/sbt-test/dependencyLockWrite/unchanged-with-config-exclusion/project/plugins.sbt
+++ b/src/sbt-test/dependencyLockWrite/unchanged-with-config-exclusion/project/plugins.sbt
@@ -1,0 +1,7 @@
+{
+  val pluginVersion = System.getProperty("plugin.version")
+  if (pluginVersion == null)
+    throw new RuntimeException("""|The system property 'plugin.version' is not defined.
+                                  |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+  else addSbtPlugin("software.purpledragon" % "sbt-dependency-lock" % pluginVersion)
+}

--- a/src/sbt-test/dependencyLockWrite/unchanged-with-config-exclusion/test
+++ b/src/sbt-test/dependencyLockWrite/unchanged-with-config-exclusion/test
@@ -1,0 +1,3 @@
+> dependencyLockWrite
+$ must-mirror build.sbt.lock build.sbt.lock.orig
+> dependencyLockCheck


### PR DESCRIPTION
Similar to filtering modules (#32), this allows you to exclude certain configurations from the lockfile, such as the Test or Optional scopes.