### PR TITLE
Add artifact URL and sha256 hash to lock file

### DIFF
--- a/src/main/scala/software/purpledragon/sbt/lock/HashingUtils.scala
+++ b/src/main/scala/software/purpledragon/sbt/lock/HashingUtils.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2019 Michael Stringer
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.purpledragon.sbt.lock
+
+import sbt.Hash
+
+import java.io.{BufferedInputStream, File, FileInputStream, InputStream}
+import java.security.{DigestInputStream, MessageDigest}
+import scala.util.{Failure, Success, Try}
+
+object HashingUtils {
+
+  def sha1(file: File): String = s"sha1:${Hash.toHex(Hash(file))}"
+
+  def sha256(file: File): String =
+    Try {
+      sha256(new BufferedInputStream(new FileInputStream(file))) // sha256 closes stream
+    } match {
+      case Failure(_) => "" // seems to pretty much be the behaviour in the SHA-1 case
+      case Success(hash) =>
+        s"sha256:${Hash.toHex(hash)}"
+    }
+
+  def sha256(stream: InputStream): Array[Byte] = {
+    val digest = MessageDigest.getInstance("SHA-256")
+    try {
+      val dis = new DigestInputStream(stream, digest)
+      val buffer = new Array[Byte](8192)
+      while (dis.read(buffer) >= 0) {}
+      dis.close()
+      digest.digest
+    } finally {
+      stream.close()
+    }
+  }
+
+}

--- a/src/main/scala/software/purpledragon/sbt/lock/model/ResolvedArtifact.scala
+++ b/src/main/scala/software/purpledragon/sbt/lock/model/ResolvedArtifact.scala
@@ -18,8 +18,9 @@ package software.purpledragon.sbt.lock.model
 
 import scala.math.Ordered.orderingToOrdered
 
-final case class ResolvedArtifact(name: String, hash: String) extends Ordered[ResolvedArtifact] {
+final case class ResolvedArtifact(name: String, sha1: String, sha256: String, url: Option[String])
+    extends Ordered[ResolvedArtifact] {
   override def compare(that: ResolvedArtifact): Int = {
-    (name, hash) compare (that.name, that.hash)
+    (name, sha1, sha256) compare (that.name, that.sha1, that.sha256)
   }
 }

--- a/src/sbt-test/dependencyLockCheck/fail-differences/build.sbt.lock
+++ b/src/sbt-test/dependencyLockCheck/fail-differences/build.sbt.lock
@@ -16,7 +16,9 @@
       "artifacts" : [
         {
           "name" : "commons-lang3.jar",
-          "hash" : "sha1:0122c7cee69b53ed4a7681c03d4ee4c0e2765da5"
+          "sha1" : "sha1:0122c7cee69b53ed4a7681c03d4ee4c0e2765da5",
+          "sha256" : "sha256:de2e1dcdcf3ef917a8ce858661a06726a9a944f28e33ad7f9e08bea44dc3c230",
+          "url" : "https://repo1.maven.org/maven2/org/apache/commons/commons-lang3/3.9/commons-lang3-3.9.jar"
         }
       ],
       "configurations" : [
@@ -32,7 +34,9 @@
       "artifacts" : [
         {
           "name" : "scala-library.jar",
-          "hash" : "sha1:3509860bc2e5b3da001ed45aca94ffbe5694dbda"
+          "sha1" : "sha1:3509860bc2e5b3da001ed45aca94ffbe5694dbda",
+          "sha256" : "sha256:0a57044d10895f8d3dd66ad4286891f607169d948845ac51e17b4c1cf0ab569d",
+          "url" : "https://repo1.maven.org/maven2/org/scala-lang/scala-library/2.12.10/scala-library-2.12.10.jar"
         }
       ],
       "configurations" : [
@@ -48,7 +52,9 @@
       "artifacts" : [
         {
           "name" : "scala-reflect.jar",
-          "hash" : "sha1:14cb7beb516cd8e07716133668c427792122c926"
+          "sha1" : "sha1:14cb7beb516cd8e07716133668c427792122c926",
+          "sha256" : "sha256:56b609e1bab9144fb51525bfa01ccd72028154fc40a58685a1e9adcbe7835730",
+          "url" : "https://repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.12.10/scala-reflect-2.12.10.jar"
         }
       ],
       "configurations" : [
@@ -62,7 +68,9 @@
       "artifacts" : [
         {
           "name" : "scala-xml_2.12.jar",
-          "hash" : "sha1:5d38ac30beb8420dd395c0af447ba412158965e6"
+          "sha1" : "sha1:5d38ac30beb8420dd395c0af447ba412158965e6",
+          "sha256" : "sha256:1b48dc206f527b7604ef32492ada8e71706c63a65d999e0cabdafdc5793b4d63",
+          "url" : "https://repo1.maven.org/maven2/org/scala-lang/modules/scala-xml_2.12/1.2.0/scala-xml_2.12-1.2.0.jar"
         }
       ],
       "configurations" : [
@@ -76,7 +84,9 @@
       "artifacts" : [
         {
           "name" : "scalactic_2.12.jar",
-          "hash" : "sha1:b50559dfc4a691c1089f9c8812e1d6fd17f80277"
+          "sha1" : "sha1:b50559dfc4a691c1089f9c8812e1d6fd17f80277",
+          "sha256" : "sha256:5f9ad122f54e9a0112ff4fcaadfb2802d8796f5dde021caa4c831067fca68469",
+          "url" : "https://repo1.maven.org/maven2/org/scalactic/scalactic_2.12/3.0.8/scalactic_2.12-3.0.8.jar"
         }
       ],
       "configurations" : [
@@ -90,7 +100,9 @@
       "artifacts" : [
         {
           "name" : "scalatest_2.12.jar",
-          "hash" : "sha1:8493ffa579676977b810a7a9fdc23af9d3c8af7f"
+          "sha1" : "sha1:8493ffa579676977b810a7a9fdc23af9d3c8af7f",
+          "sha256" : "sha256:a4045cea66f3eaab525696f3000d7d610593778bd070e98349a7066f872844cd",
+          "url" : "https://repo1.maven.org/maven2/org/scalatest/scalatest_2.12/3.0.8/scalatest_2.12-3.0.8.jar"
         }
       ],
       "configurations" : [

--- a/src/sbt-test/dependencyLockCheck/pass-different-order/build.sbt.lock
+++ b/src/sbt-test/dependencyLockCheck/pass-different-order/build.sbt.lock
@@ -16,7 +16,9 @@
       "artifacts" : [
         {
           "name" : "scala-library.jar",
-          "hash" : "sha1:3509860bc2e5b3da001ed45aca94ffbe5694dbda"
+          "sha1" : "sha1:3509860bc2e5b3da001ed45aca94ffbe5694dbda",
+          "sha256" : "sha256:0a57044d10895f8d3dd66ad4286891f607169d948845ac51e17b4c1cf0ab569d",
+          "url" : "https://repo1.maven.org/maven2/org/scala-lang/scala-library/2.12.10/scala-library-2.12.10.jar"
         }
       ],
       "configurations" : [
@@ -32,7 +34,9 @@
       "artifacts" : [
         {
           "name" : "scala-xml_2.12.jar",
-          "hash" : "sha1:5d38ac30beb8420dd395c0af447ba412158965e6"
+          "sha1" : "sha1:5d38ac30beb8420dd395c0af447ba412158965e6",
+          "sha256" : "sha256:1b48dc206f527b7604ef32492ada8e71706c63a65d999e0cabdafdc5793b4d63",
+          "url" : "https://repo1.maven.org/maven2/org/scala-lang/modules/scala-xml_2.12/1.2.0/scala-xml_2.12-1.2.0.jar"
         }
       ],
       "configurations" : [
@@ -46,7 +50,9 @@
       "artifacts" : [
         {
           "name" : "scala-reflect.jar",
-          "hash" : "sha1:14cb7beb516cd8e07716133668c427792122c926"
+          "sha1" : "sha1:14cb7beb516cd8e07716133668c427792122c926",
+          "sha256" : "sha256:56b609e1bab9144fb51525bfa01ccd72028154fc40a58685a1e9adcbe7835730",
+          "url" : "https://repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.12.10/scala-reflect-2.12.10.jar"
         }
       ],
       "configurations" : [
@@ -60,7 +66,9 @@
       "artifacts" : [
         {
           "name" : "scalactic_2.12.jar",
-          "hash" : "sha1:b50559dfc4a691c1089f9c8812e1d6fd17f80277"
+          "sha1" : "sha1:b50559dfc4a691c1089f9c8812e1d6fd17f80277",
+          "sha256" : "sha256:5f9ad122f54e9a0112ff4fcaadfb2802d8796f5dde021caa4c831067fca68469",
+          "url" : "https://repo1.maven.org/maven2/org/scalactic/scalactic_2.12/3.0.8/scalactic_2.12-3.0.8.jar"
         }
       ],
       "configurations" : [
@@ -74,7 +82,9 @@
       "artifacts" : [
         {
           "name" : "commons-lang3.jar",
-          "hash" : "sha1:0122c7cee69b53ed4a7681c03d4ee4c0e2765da5"
+          "sha1" : "sha1:0122c7cee69b53ed4a7681c03d4ee4c0e2765da5",
+          "sha256" : "sha256:de2e1dcdcf3ef917a8ce858661a06726a9a944f28e33ad7f9e08bea44dc3c230",
+          "url" : "https://repo1.maven.org/maven2/org/apache/commons/commons-lang3/3.9/commons-lang3-3.9.jar"
         }
       ],
       "configurations" : [
@@ -90,7 +100,9 @@
       "artifacts" : [
         {
           "name" : "scalatest_2.12.jar",
-          "hash" : "sha1:8493ffa579676977b810a7a9fdc23af9d3c8af7f"
+          "sha1" : "sha1:8493ffa579676977b810a7a9fdc23af9d3c8af7f",
+          "sha256" : "sha256:a4045cea66f3eaab525696f3000d7d610593778bd070e98349a7066f872844cd",
+          "url" : "https://repo1.maven.org/maven2/org/scalatest/scalatest_2.12/3.0.8/scalatest_2.12-3.0.8.jar"
         }
       ],
       "configurations" : [

--- a/src/sbt-test/dependencyLockCheck/pass-with-config-exclusion/build.sbt.lock
+++ b/src/sbt-test/dependencyLockCheck/pass-with-config-exclusion/build.sbt.lock
@@ -15,7 +15,9 @@
       "artifacts" : [
         {
           "name" : "commons-lang3.jar",
-          "hash" : "sha1:0122c7cee69b53ed4a7681c03d4ee4c0e2765da5"
+          "sha1" : "sha1:0122c7cee69b53ed4a7681c03d4ee4c0e2765da5",
+          "sha256" : "sha256:de2e1dcdcf3ef917a8ce858661a06726a9a944f28e33ad7f9e08bea44dc3c230",
+          "url" : "https://repo1.maven.org/maven2/org/apache/commons/commons-lang3/3.9/commons-lang3-3.9.jar"
         }
       ],
       "configurations" : [
@@ -30,7 +32,9 @@
       "artifacts" : [
         {
           "name" : "scala-library.jar",
-          "hash" : "sha1:3509860bc2e5b3da001ed45aca94ffbe5694dbda"
+          "sha1" : "sha1:3509860bc2e5b3da001ed45aca94ffbe5694dbda",
+          "sha256" : "sha256:0a57044d10895f8d3dd66ad4286891f607169d948845ac51e17b4c1cf0ab569d",
+          "url" : "https://repo1.maven.org/maven2/org/scala-lang/scala-library/2.12.10/scala-library-2.12.10.jar"
         }
       ],
       "configurations" : [

--- a/src/sbt-test/dependencyLockCheck/pass-with-exclusion/build.sbt.lock
+++ b/src/sbt-test/dependencyLockCheck/pass-with-exclusion/build.sbt.lock
@@ -16,7 +16,9 @@
       "artifacts" : [
         {
           "name" : "scala-library.jar",
-          "hash" : "sha1:3509860bc2e5b3da001ed45aca94ffbe5694dbda"
+          "sha1" : "sha1:3509860bc2e5b3da001ed45aca94ffbe5694dbda",
+          "sha256" : "sha256:0a57044d10895f8d3dd66ad4286891f607169d948845ac51e17b4c1cf0ab569d",
+          "url" : "https://repo1.maven.org/maven2/org/scala-lang/scala-library/2.12.10/scala-library-2.12.10.jar"
         }
       ],
       "configurations" : [
@@ -32,7 +34,9 @@
       "artifacts" : [
         {
           "name" : "scala-reflect.jar",
-          "hash" : "sha1:14cb7beb516cd8e07716133668c427792122c926"
+          "sha1" : "sha1:14cb7beb516cd8e07716133668c427792122c926",
+          "sha256" : "sha256:56b609e1bab9144fb51525bfa01ccd72028154fc40a58685a1e9adcbe7835730",
+          "url" : "https://repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.12.10/scala-reflect-2.12.10.jar"
         }
       ],
       "configurations" : [
@@ -46,7 +50,9 @@
       "artifacts" : [
         {
           "name" : "scala-xml_2.12.jar",
-          "hash" : "sha1:5d38ac30beb8420dd395c0af447ba412158965e6"
+          "sha1" : "sha1:5d38ac30beb8420dd395c0af447ba412158965e6",
+          "sha256" : "sha256:1b48dc206f527b7604ef32492ada8e71706c63a65d999e0cabdafdc5793b4d63",
+          "url" : "https://repo1.maven.org/maven2/org/scala-lang/modules/scala-xml_2.12/1.2.0/scala-xml_2.12-1.2.0.jar"
         }
       ],
       "configurations" : [
@@ -60,7 +66,9 @@
       "artifacts" : [
         {
           "name" : "scalactic_2.12.jar",
-          "hash" : "sha1:b50559dfc4a691c1089f9c8812e1d6fd17f80277"
+          "sha1" : "sha1:b50559dfc4a691c1089f9c8812e1d6fd17f80277",
+          "sha256" : "sha256:5f9ad122f54e9a0112ff4fcaadfb2802d8796f5dde021caa4c831067fca68469",
+          "url" : "https://repo1.maven.org/maven2/org/scalactic/scalactic_2.12/3.0.8/scalactic_2.12-3.0.8.jar"
         }
       ],
       "configurations" : [
@@ -74,7 +82,9 @@
       "artifacts" : [
         {
           "name" : "scalatest_2.12.jar",
-          "hash" : "sha1:8493ffa579676977b810a7a9fdc23af9d3c8af7f"
+          "sha1" : "sha1:8493ffa579676977b810a7a9fdc23af9d3c8af7f",
+          "sha256" : "sha256:a4045cea66f3eaab525696f3000d7d610593778bd070e98349a7066f872844cd",
+          "url" : "https://repo1.maven.org/maven2/org/scalatest/scalatest_2.12/3.0.8/scalatest_2.12-3.0.8.jar"
         }
       ],
       "configurations" : [

--- a/src/sbt-test/dependencyLockCheck/pass/build.sbt.lock
+++ b/src/sbt-test/dependencyLockCheck/pass/build.sbt.lock
@@ -16,7 +16,9 @@
       "artifacts" : [
         {
           "name" : "commons-lang3.jar",
-          "hash" : "sha1:0122c7cee69b53ed4a7681c03d4ee4c0e2765da5"
+          "sha1" : "sha1:0122c7cee69b53ed4a7681c03d4ee4c0e2765da5",
+          "sha256" : "sha256:de2e1dcdcf3ef917a8ce858661a06726a9a944f28e33ad7f9e08bea44dc3c230",
+          "url" : "https://repo1.maven.org/maven2/org/apache/commons/commons-lang3/3.9/commons-lang3-3.9.jar"
         }
       ],
       "configurations" : [
@@ -32,7 +34,9 @@
       "artifacts" : [
         {
           "name" : "scala-library.jar",
-          "hash" : "sha1:3509860bc2e5b3da001ed45aca94ffbe5694dbda"
+          "sha1" : "sha1:3509860bc2e5b3da001ed45aca94ffbe5694dbda",
+          "sha256" : "sha256:0a57044d10895f8d3dd66ad4286891f607169d948845ac51e17b4c1cf0ab569d",
+          "url" : "https://repo1.maven.org/maven2/org/scala-lang/scala-library/2.12.10/scala-library-2.12.10.jar"
         }
       ],
       "configurations" : [
@@ -48,7 +52,9 @@
       "artifacts" : [
         {
           "name" : "scala-reflect.jar",
-          "hash" : "sha1:14cb7beb516cd8e07716133668c427792122c926"
+          "sha1" : "sha1:14cb7beb516cd8e07716133668c427792122c926",
+          "sha256" : "sha256:56b609e1bab9144fb51525bfa01ccd72028154fc40a58685a1e9adcbe7835730",
+          "url" : "https://repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.12.10/scala-reflect-2.12.10.jar"
         }
       ],
       "configurations" : [
@@ -62,7 +68,9 @@
       "artifacts" : [
         {
           "name" : "scala-xml_2.12.jar",
-          "hash" : "sha1:5d38ac30beb8420dd395c0af447ba412158965e6"
+          "sha1" : "sha1:5d38ac30beb8420dd395c0af447ba412158965e6",
+          "sha256" : "sha256:1b48dc206f527b7604ef32492ada8e71706c63a65d999e0cabdafdc5793b4d63",
+          "url" : "https://repo1.maven.org/maven2/org/scala-lang/modules/scala-xml_2.12/1.2.0/scala-xml_2.12-1.2.0.jar"
         }
       ],
       "configurations" : [
@@ -76,7 +84,9 @@
       "artifacts" : [
         {
           "name" : "scalactic_2.12.jar",
-          "hash" : "sha1:b50559dfc4a691c1089f9c8812e1d6fd17f80277"
+          "sha1" : "sha1:b50559dfc4a691c1089f9c8812e1d6fd17f80277",
+          "sha256" : "sha256:5f9ad122f54e9a0112ff4fcaadfb2802d8796f5dde021caa4c831067fca68469",
+          "url" : "https://repo1.maven.org/maven2/org/scalactic/scalactic_2.12/3.0.8/scalactic_2.12-3.0.8.jar"
         }
       ],
       "configurations" : [
@@ -90,7 +100,9 @@
       "artifacts" : [
         {
           "name" : "scalatest_2.12.jar",
-          "hash" : "sha1:8493ffa579676977b810a7a9fdc23af9d3c8af7f"
+          "sha1" : "sha1:8493ffa579676977b810a7a9fdc23af9d3c8af7f",
+          "sha256" : "sha256:a4045cea66f3eaab525696f3000d7d610593778bd070e98349a7066f872844cd",
+          "url" : "https://repo1.maven.org/maven2/org/scalatest/scalatest_2.12/3.0.8/scalatest_2.12-3.0.8.jar"
         }
       ],
       "configurations" : [

--- a/src/sbt-test/dependencyLockWrite/differences/build.sbt.lock
+++ b/src/sbt-test/dependencyLockWrite/differences/build.sbt.lock
@@ -16,7 +16,9 @@
       "artifacts" : [
         {
           "name" : "commons-lang3.jar",
-          "hash" : "sha1:0122c7cee69b53ed4a7681c03d4ee4c0e2765da5"
+          "sha1" : "sha1:0122c7cee69b53ed4a7681c03d4ee4c0e2765da5",
+          "sha256" : "sha256:de2e1dcdcf3ef917a8ce858661a06726a9a944f28e33ad7f9e08bea44dc3c230",
+          "url" : "https://repo1.maven.org/maven2/org/apache/commons/commons-lang3/3.9/commons-lang3-3.9.jar"
         }
       ],
       "configurations" : [
@@ -32,7 +34,9 @@
       "artifacts" : [
         {
           "name" : "scala-library.jar",
-          "hash" : "sha1:3509860bc2e5b3da001ed45aca94ffbe5694dbda"
+          "sha1" : "sha1:3509860bc2e5b3da001ed45aca94ffbe5694dbda",
+          "sha256" : "sha256:0a57044d10895f8d3dd66ad4286891f607169d948845ac51e17b4c1cf0ab569d",
+          "url" : "https://repo1.maven.org/maven2/org/scala-lang/scala-library/2.12.10/scala-library-2.12.10.jar"
         }
       ],
       "configurations" : [
@@ -48,7 +52,9 @@
       "artifacts" : [
         {
           "name" : "scala-reflect.jar",
-          "hash" : "sha1:14cb7beb516cd8e07716133668c427792122c926"
+          "sha1" : "sha1:14cb7beb516cd8e07716133668c427792122c926",
+          "sha256" : "sha256:56b609e1bab9144fb51525bfa01ccd72028154fc40a58685a1e9adcbe7835730",
+          "url" : "https://repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.12.10/scala-reflect-2.12.10.jar"
         }
       ],
       "configurations" : [
@@ -62,7 +68,9 @@
       "artifacts" : [
         {
           "name" : "scala-xml_2.12.jar",
-          "hash" : "sha1:5d38ac30beb8420dd395c0af447ba412158965e6"
+          "sha1" : "sha1:5d38ac30beb8420dd395c0af447ba412158965e6",
+          "sha256" : "sha256:1b48dc206f527b7604ef32492ada8e71706c63a65d999e0cabdafdc5793b4d63",
+          "url" : "https://repo1.maven.org/maven2/org/scala-lang/modules/scala-xml_2.12/1.2.0/scala-xml_2.12-1.2.0.jar"
         }
       ],
       "configurations" : [
@@ -76,7 +84,9 @@
       "artifacts" : [
         {
           "name" : "scalactic_2.12.jar",
-          "hash" : "sha1:b50559dfc4a691c1089f9c8812e1d6fd17f80277"
+          "sha1" : "sha1:b50559dfc4a691c1089f9c8812e1d6fd17f80277",
+          "sha256" : "sha256:5f9ad122f54e9a0112ff4fcaadfb2802d8796f5dde021caa4c831067fca68469",
+          "url" : "https://repo1.maven.org/maven2/org/scalactic/scalactic_2.12/3.0.8/scalactic_2.12-3.0.8.jar"
         }
       ],
       "configurations" : [
@@ -90,7 +100,9 @@
       "artifacts" : [
         {
           "name" : "scalatest_2.12.jar",
-          "hash" : "sha1:8493ffa579676977b810a7a9fdc23af9d3c8af7f"
+          "sha1" : "sha1:8493ffa579676977b810a7a9fdc23af9d3c8af7f",
+          "sha256" : "sha256:a4045cea66f3eaab525696f3000d7d610593778bd070e98349a7066f872844cd",
+          "url" : "https://repo1.maven.org/maven2/org/scalatest/scalatest_2.12/3.0.8/scalatest_2.12-3.0.8.jar"
         }
       ],
       "configurations" : [

--- a/src/sbt-test/dependencyLockWrite/differences/build.sbt.lock.orig
+++ b/src/sbt-test/dependencyLockWrite/differences/build.sbt.lock.orig
@@ -16,7 +16,9 @@
       "artifacts" : [
         {
           "name" : "commons-lang3.jar",
-          "hash" : "sha1:0122c7cee69b53ed4a7681c03d4ee4c0e2765da5"
+          "sha1" : "sha1:0122c7cee69b53ed4a7681c03d4ee4c0e2765da5",
+          "sha256" : "sha256:de2e1dcdcf3ef917a8ce858661a06726a9a944f28e33ad7f9e08bea44dc3c230",
+          "url" : "https://repo1.maven.org/maven2/org/apache/commons/commons-lang3/3.9/commons-lang3-3.9.jar"
         }
       ],
       "configurations" : [
@@ -32,7 +34,9 @@
       "artifacts" : [
         {
           "name" : "scala-library.jar",
-          "hash" : "sha1:3509860bc2e5b3da001ed45aca94ffbe5694dbda"
+          "sha1" : "sha1:3509860bc2e5b3da001ed45aca94ffbe5694dbda",
+          "sha256" : "sha256:0a57044d10895f8d3dd66ad4286891f607169d948845ac51e17b4c1cf0ab569d",
+          "url" : "https://repo1.maven.org/maven2/org/scala-lang/scala-library/2.12.10/scala-library-2.12.10.jar"
         }
       ],
       "configurations" : [
@@ -48,7 +52,9 @@
       "artifacts" : [
         {
           "name" : "scala-reflect.jar",
-          "hash" : "sha1:14cb7beb516cd8e07716133668c427792122c926"
+          "sha1" : "sha1:14cb7beb516cd8e07716133668c427792122c926",
+          "sha256" : "sha256:56b609e1bab9144fb51525bfa01ccd72028154fc40a58685a1e9adcbe7835730",
+          "url" : "https://repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.12.10/scala-reflect-2.12.10.jar"
         }
       ],
       "configurations" : [
@@ -62,7 +68,9 @@
       "artifacts" : [
         {
           "name" : "scala-xml_2.12.jar",
-          "hash" : "sha1:5d38ac30beb8420dd395c0af447ba412158965e6"
+          "sha1" : "sha1:5d38ac30beb8420dd395c0af447ba412158965e6",
+          "sha256" : "sha256:1b48dc206f527b7604ef32492ada8e71706c63a65d999e0cabdafdc5793b4d63",
+          "url" : "https://repo1.maven.org/maven2/org/scala-lang/modules/scala-xml_2.12/1.2.0/scala-xml_2.12-1.2.0.jar"
         }
       ],
       "configurations" : [
@@ -76,7 +84,9 @@
       "artifacts" : [
         {
           "name" : "scalactic_2.12.jar",
-          "hash" : "sha1:b50559dfc4a691c1089f9c8812e1d6fd17f80277"
+          "sha1" : "sha1:b50559dfc4a691c1089f9c8812e1d6fd17f80277",
+          "sha256" : "sha256:5f9ad122f54e9a0112ff4fcaadfb2802d8796f5dde021caa4c831067fca68469",
+          "url" : "https://repo1.maven.org/maven2/org/scalactic/scalactic_2.12/3.0.8/scalactic_2.12-3.0.8.jar"
         }
       ],
       "configurations" : [
@@ -90,7 +100,9 @@
       "artifacts" : [
         {
           "name" : "scalatest_2.12.jar",
-          "hash" : "sha1:8493ffa579676977b810a7a9fdc23af9d3c8af7f"
+          "sha1" : "sha1:8493ffa579676977b810a7a9fdc23af9d3c8af7f",
+          "sha256" : "sha256:a4045cea66f3eaab525696f3000d7d610593778bd070e98349a7066f872844cd",
+          "url" : "https://repo1.maven.org/maven2/org/scalatest/scalatest_2.12/3.0.8/scalatest_2.12-3.0.8.jar"
         }
       ],
       "configurations" : [

--- a/src/sbt-test/dependencyLockWrite/unchanged-with-config-exclusion/build.sbt.lock
+++ b/src/sbt-test/dependencyLockWrite/unchanged-with-config-exclusion/build.sbt.lock
@@ -15,7 +15,9 @@
       "artifacts" : [
         {
           "name" : "commons-lang3.jar",
-          "hash" : "sha1:0122c7cee69b53ed4a7681c03d4ee4c0e2765da5"
+          "sha1" : "sha1:0122c7cee69b53ed4a7681c03d4ee4c0e2765da5",
+          "sha256" : "sha256:de2e1dcdcf3ef917a8ce858661a06726a9a944f28e33ad7f9e08bea44dc3c230",
+          "url" : "https://repo1.maven.org/maven2/org/apache/commons/commons-lang3/3.9/commons-lang3-3.9.jar"
         }
       ],
       "configurations" : [
@@ -30,7 +32,9 @@
       "artifacts" : [
         {
           "name" : "scala-library.jar",
-          "hash" : "sha1:3509860bc2e5b3da001ed45aca94ffbe5694dbda"
+          "sha1" : "sha1:3509860bc2e5b3da001ed45aca94ffbe5694dbda",
+          "sha256" : "sha256:0a57044d10895f8d3dd66ad4286891f607169d948845ac51e17b4c1cf0ab569d",
+          "url" : "https://repo1.maven.org/maven2/org/scala-lang/scala-library/2.12.10/scala-library-2.12.10.jar"
         }
       ],
       "configurations" : [

--- a/src/sbt-test/dependencyLockWrite/unchanged-with-config-exclusion/build.sbt.lock.orig
+++ b/src/sbt-test/dependencyLockWrite/unchanged-with-config-exclusion/build.sbt.lock.orig
@@ -15,7 +15,9 @@
       "artifacts" : [
         {
           "name" : "commons-lang3.jar",
-          "hash" : "sha1:0122c7cee69b53ed4a7681c03d4ee4c0e2765da5"
+          "sha1" : "sha1:0122c7cee69b53ed4a7681c03d4ee4c0e2765da5",
+          "sha256" : "sha256:de2e1dcdcf3ef917a8ce858661a06726a9a944f28e33ad7f9e08bea44dc3c230",
+          "url" : "https://repo1.maven.org/maven2/org/apache/commons/commons-lang3/3.9/commons-lang3-3.9.jar"
         }
       ],
       "configurations" : [
@@ -30,7 +32,9 @@
       "artifacts" : [
         {
           "name" : "scala-library.jar",
-          "hash" : "sha1:3509860bc2e5b3da001ed45aca94ffbe5694dbda"
+          "sha1" : "sha1:3509860bc2e5b3da001ed45aca94ffbe5694dbda",
+          "sha256" : "sha256:0a57044d10895f8d3dd66ad4286891f607169d948845ac51e17b4c1cf0ab569d",
+          "url" : "https://repo1.maven.org/maven2/org/scala-lang/scala-library/2.12.10/scala-library-2.12.10.jar"
         }
       ],
       "configurations" : [

--- a/src/sbt-test/dependencyLockWrite/unchanged-with-exclusion/build.sbt.lock
+++ b/src/sbt-test/dependencyLockWrite/unchanged-with-exclusion/build.sbt.lock
@@ -16,7 +16,9 @@
       "artifacts" : [
         {
           "name" : "commons-lang3.jar",
-          "hash" : "sha1:0122c7cee69b53ed4a7681c03d4ee4c0e2765da5"
+          "sha1" : "sha1:0122c7cee69b53ed4a7681c03d4ee4c0e2765da5",
+          "sha256" : "sha256:de2e1dcdcf3ef917a8ce858661a06726a9a944f28e33ad7f9e08bea44dc3c230",
+          "url" : "https://repo1.maven.org/maven2/org/apache/commons/commons-lang3/3.9/commons-lang3-3.9.jar"
         }
       ],
       "configurations" : [
@@ -32,7 +34,9 @@
       "artifacts" : [
         {
           "name" : "scala-library.jar",
-          "hash" : "sha1:3509860bc2e5b3da001ed45aca94ffbe5694dbda"
+          "sha1" : "sha1:3509860bc2e5b3da001ed45aca94ffbe5694dbda",
+          "sha256" : "sha256:0a57044d10895f8d3dd66ad4286891f607169d948845ac51e17b4c1cf0ab569d",
+          "url" : "https://repo1.maven.org/maven2/org/scala-lang/scala-library/2.12.10/scala-library-2.12.10.jar"
         }
       ],
       "configurations" : [
@@ -48,7 +52,9 @@
       "artifacts" : [
         {
           "name" : "scala-reflect.jar",
-          "hash" : "sha1:14cb7beb516cd8e07716133668c427792122c926"
+          "sha1" : "sha1:14cb7beb516cd8e07716133668c427792122c926",
+          "sha256" : "sha256:56b609e1bab9144fb51525bfa01ccd72028154fc40a58685a1e9adcbe7835730",
+          "url" : "https://repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.12.10/scala-reflect-2.12.10.jar"
         }
       ],
       "configurations" : [
@@ -62,7 +68,9 @@
       "artifacts" : [
         {
           "name" : "scala-xml_2.12.jar",
-          "hash" : "sha1:5d38ac30beb8420dd395c0af447ba412158965e6"
+          "sha1" : "sha1:5d38ac30beb8420dd395c0af447ba412158965e6",
+          "sha256" : "sha256:1b48dc206f527b7604ef32492ada8e71706c63a65d999e0cabdafdc5793b4d63",
+          "url" : "https://repo1.maven.org/maven2/org/scala-lang/modules/scala-xml_2.12/1.2.0/scala-xml_2.12-1.2.0.jar"
         }
       ],
       "configurations" : [
@@ -76,7 +84,9 @@
       "artifacts" : [
         {
           "name" : "scalactic_2.12.jar",
-          "hash" : "sha1:b50559dfc4a691c1089f9c8812e1d6fd17f80277"
+          "sha1" : "sha1:b50559dfc4a691c1089f9c8812e1d6fd17f80277",
+          "sha256" : "sha256:5f9ad122f54e9a0112ff4fcaadfb2802d8796f5dde021caa4c831067fca68469",
+          "url" : "https://repo1.maven.org/maven2/org/scalactic/scalactic_2.12/3.0.8/scalactic_2.12-3.0.8.jar"
         }
       ],
       "configurations" : [

--- a/src/sbt-test/dependencyLockWrite/unchanged-with-exclusion/build.sbt.lock.orig
+++ b/src/sbt-test/dependencyLockWrite/unchanged-with-exclusion/build.sbt.lock.orig
@@ -16,7 +16,9 @@
       "artifacts" : [
         {
           "name" : "commons-lang3.jar",
-          "hash" : "sha1:0122c7cee69b53ed4a7681c03d4ee4c0e2765da5"
+          "sha1" : "sha1:0122c7cee69b53ed4a7681c03d4ee4c0e2765da5",
+          "sha256" : "sha256:de2e1dcdcf3ef917a8ce858661a06726a9a944f28e33ad7f9e08bea44dc3c230",
+          "url" : "https://repo1.maven.org/maven2/org/apache/commons/commons-lang3/3.9/commons-lang3-3.9.jar"
         }
       ],
       "configurations" : [
@@ -32,7 +34,9 @@
       "artifacts" : [
         {
           "name" : "scala-library.jar",
-          "hash" : "sha1:3509860bc2e5b3da001ed45aca94ffbe5694dbda"
+          "sha1" : "sha1:3509860bc2e5b3da001ed45aca94ffbe5694dbda",
+          "sha256" : "sha256:0a57044d10895f8d3dd66ad4286891f607169d948845ac51e17b4c1cf0ab569d",
+          "url" : "https://repo1.maven.org/maven2/org/scala-lang/scala-library/2.12.10/scala-library-2.12.10.jar"
         }
       ],
       "configurations" : [
@@ -48,7 +52,9 @@
       "artifacts" : [
         {
           "name" : "scala-reflect.jar",
-          "hash" : "sha1:14cb7beb516cd8e07716133668c427792122c926"
+          "sha1" : "sha1:14cb7beb516cd8e07716133668c427792122c926",
+          "sha256" : "sha256:56b609e1bab9144fb51525bfa01ccd72028154fc40a58685a1e9adcbe7835730",
+          "url" : "https://repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.12.10/scala-reflect-2.12.10.jar"
         }
       ],
       "configurations" : [
@@ -62,7 +68,9 @@
       "artifacts" : [
         {
           "name" : "scala-xml_2.12.jar",
-          "hash" : "sha1:5d38ac30beb8420dd395c0af447ba412158965e6"
+          "sha1" : "sha1:5d38ac30beb8420dd395c0af447ba412158965e6",
+          "sha256" : "sha256:1b48dc206f527b7604ef32492ada8e71706c63a65d999e0cabdafdc5793b4d63",
+          "url" : "https://repo1.maven.org/maven2/org/scala-lang/modules/scala-xml_2.12/1.2.0/scala-xml_2.12-1.2.0.jar"
         }
       ],
       "configurations" : [
@@ -76,7 +84,9 @@
       "artifacts" : [
         {
           "name" : "scalactic_2.12.jar",
-          "hash" : "sha1:b50559dfc4a691c1089f9c8812e1d6fd17f80277"
+          "sha1" : "sha1:b50559dfc4a691c1089f9c8812e1d6fd17f80277",
+          "sha256" : "sha256:5f9ad122f54e9a0112ff4fcaadfb2802d8796f5dde021caa4c831067fca68469",
+          "url" : "https://repo1.maven.org/maven2/org/scalactic/scalactic_2.12/3.0.8/scalactic_2.12-3.0.8.jar"
         }
       ],
       "configurations" : [

--- a/src/sbt-test/dependencyLockWrite/unchanged/build.sbt.lock
+++ b/src/sbt-test/dependencyLockWrite/unchanged/build.sbt.lock
@@ -16,7 +16,9 @@
       "artifacts" : [
         {
           "name" : "commons-lang3.jar",
-          "hash" : "sha1:0122c7cee69b53ed4a7681c03d4ee4c0e2765da5"
+          "sha1" : "sha1:0122c7cee69b53ed4a7681c03d4ee4c0e2765da5",
+          "sha256" : "sha256:de2e1dcdcf3ef917a8ce858661a06726a9a944f28e33ad7f9e08bea44dc3c230",
+          "url" : "https://repo1.maven.org/maven2/org/apache/commons/commons-lang3/3.9/commons-lang3-3.9.jar"
         }
       ],
       "configurations" : [
@@ -32,7 +34,9 @@
       "artifacts" : [
         {
           "name" : "scala-library.jar",
-          "hash" : "sha1:3509860bc2e5b3da001ed45aca94ffbe5694dbda"
+          "sha1" : "sha1:3509860bc2e5b3da001ed45aca94ffbe5694dbda",
+          "sha256" : "sha256:0a57044d10895f8d3dd66ad4286891f607169d948845ac51e17b4c1cf0ab569d",
+          "url" : "https://repo1.maven.org/maven2/org/scala-lang/scala-library/2.12.10/scala-library-2.12.10.jar"
         }
       ],
       "configurations" : [
@@ -48,7 +52,9 @@
       "artifacts" : [
         {
           "name" : "scala-reflect.jar",
-          "hash" : "sha1:14cb7beb516cd8e07716133668c427792122c926"
+          "sha1" : "sha1:14cb7beb516cd8e07716133668c427792122c926",
+          "sha256" : "sha256:56b609e1bab9144fb51525bfa01ccd72028154fc40a58685a1e9adcbe7835730",
+          "url" : "https://repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.12.10/scala-reflect-2.12.10.jar"
         }
       ],
       "configurations" : [
@@ -62,7 +68,9 @@
       "artifacts" : [
         {
           "name" : "scala-xml_2.12.jar",
-          "hash" : "sha1:5d38ac30beb8420dd395c0af447ba412158965e6"
+          "sha1" : "sha1:5d38ac30beb8420dd395c0af447ba412158965e6",
+          "sha256" : "sha256:1b48dc206f527b7604ef32492ada8e71706c63a65d999e0cabdafdc5793b4d63",
+          "url" : "https://repo1.maven.org/maven2/org/scala-lang/modules/scala-xml_2.12/1.2.0/scala-xml_2.12-1.2.0.jar"
         }
       ],
       "configurations" : [
@@ -76,7 +84,9 @@
       "artifacts" : [
         {
           "name" : "scalactic_2.12.jar",
-          "hash" : "sha1:b50559dfc4a691c1089f9c8812e1d6fd17f80277"
+          "sha1" : "sha1:b50559dfc4a691c1089f9c8812e1d6fd17f80277",
+          "sha256" : "sha256:5f9ad122f54e9a0112ff4fcaadfb2802d8796f5dde021caa4c831067fca68469",
+          "url" : "https://repo1.maven.org/maven2/org/scalactic/scalactic_2.12/3.0.8/scalactic_2.12-3.0.8.jar"
         }
       ],
       "configurations" : [
@@ -90,7 +100,9 @@
       "artifacts" : [
         {
           "name" : "scalatest_2.12.jar",
-          "hash" : "sha1:8493ffa579676977b810a7a9fdc23af9d3c8af7f"
+          "sha1" : "sha1:8493ffa579676977b810a7a9fdc23af9d3c8af7f",
+          "sha256" : "sha256:a4045cea66f3eaab525696f3000d7d610593778bd070e98349a7066f872844cd",
+          "url" : "https://repo1.maven.org/maven2/org/scalatest/scalatest_2.12/3.0.8/scalatest_2.12-3.0.8.jar"
         }
       ],
       "configurations" : [

--- a/src/sbt-test/dependencyLockWrite/unchanged/build.sbt.lock.orig
+++ b/src/sbt-test/dependencyLockWrite/unchanged/build.sbt.lock.orig
@@ -16,7 +16,9 @@
       "artifacts" : [
         {
           "name" : "commons-lang3.jar",
-          "hash" : "sha1:0122c7cee69b53ed4a7681c03d4ee4c0e2765da5"
+          "sha1" : "sha1:0122c7cee69b53ed4a7681c03d4ee4c0e2765da5",
+          "sha256" : "sha256:de2e1dcdcf3ef917a8ce858661a06726a9a944f28e33ad7f9e08bea44dc3c230",
+          "url" : "https://repo1.maven.org/maven2/org/apache/commons/commons-lang3/3.9/commons-lang3-3.9.jar"
         }
       ],
       "configurations" : [
@@ -32,7 +34,9 @@
       "artifacts" : [
         {
           "name" : "scala-library.jar",
-          "hash" : "sha1:3509860bc2e5b3da001ed45aca94ffbe5694dbda"
+          "sha1" : "sha1:3509860bc2e5b3da001ed45aca94ffbe5694dbda",
+          "sha256" : "sha256:0a57044d10895f8d3dd66ad4286891f607169d948845ac51e17b4c1cf0ab569d",
+          "url" : "https://repo1.maven.org/maven2/org/scala-lang/scala-library/2.12.10/scala-library-2.12.10.jar"
         }
       ],
       "configurations" : [
@@ -48,7 +52,9 @@
       "artifacts" : [
         {
           "name" : "scala-reflect.jar",
-          "hash" : "sha1:14cb7beb516cd8e07716133668c427792122c926"
+          "sha1" : "sha1:14cb7beb516cd8e07716133668c427792122c926",
+          "sha256" : "sha256:56b609e1bab9144fb51525bfa01ccd72028154fc40a58685a1e9adcbe7835730",
+          "url" : "https://repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.12.10/scala-reflect-2.12.10.jar"
         }
       ],
       "configurations" : [
@@ -62,7 +68,9 @@
       "artifacts" : [
         {
           "name" : "scala-xml_2.12.jar",
-          "hash" : "sha1:5d38ac30beb8420dd395c0af447ba412158965e6"
+          "sha1" : "sha1:5d38ac30beb8420dd395c0af447ba412158965e6",
+          "sha256" : "sha256:1b48dc206f527b7604ef32492ada8e71706c63a65d999e0cabdafdc5793b4d63",
+          "url" : "https://repo1.maven.org/maven2/org/scala-lang/modules/scala-xml_2.12/1.2.0/scala-xml_2.12-1.2.0.jar"
         }
       ],
       "configurations" : [
@@ -76,7 +84,9 @@
       "artifacts" : [
         {
           "name" : "scalactic_2.12.jar",
-          "hash" : "sha1:b50559dfc4a691c1089f9c8812e1d6fd17f80277"
+          "sha1" : "sha1:b50559dfc4a691c1089f9c8812e1d6fd17f80277",
+          "sha256" : "sha256:5f9ad122f54e9a0112ff4fcaadfb2802d8796f5dde021caa4c831067fca68469",
+          "url" : "https://repo1.maven.org/maven2/org/scalactic/scalactic_2.12/3.0.8/scalactic_2.12-3.0.8.jar"
         }
       ],
       "configurations" : [
@@ -90,7 +100,9 @@
       "artifacts" : [
         {
           "name" : "scalatest_2.12.jar",
-          "hash" : "sha1:8493ffa579676977b810a7a9fdc23af9d3c8af7f"
+          "sha1" : "sha1:8493ffa579676977b810a7a9fdc23af9d3c8af7f",
+          "sha256" : "sha256:a4045cea66f3eaab525696f3000d7d610593778bd070e98349a7066f872844cd",
+          "url" : "https://repo1.maven.org/maven2/org/scalatest/scalatest_2.12/3.0.8/scalatest_2.12-3.0.8.jar"
         }
       ],
       "configurations" : [

--- a/src/sbt-test/update/auto-update-differences/build.sbt.lock
+++ b/src/sbt-test/update/auto-update-differences/build.sbt.lock
@@ -16,7 +16,9 @@
       "artifacts" : [
         {
           "name" : "commons-lang3.jar",
-          "hash" : "sha1:0122c7cee69b53ed4a7681c03d4ee4c0e2765da5"
+          "sha1" : "sha1:0122c7cee69b53ed4a7681c03d4ee4c0e2765da5",
+          "sha256" : "sha256:de2e1dcdcf3ef917a8ce858661a06726a9a944f28e33ad7f9e08bea44dc3c230",
+          "url" : "https://repo1.maven.org/maven2/org/apache/commons/commons-lang3/3.9/commons-lang3-3.9.jar"
         }
       ],
       "configurations" : [
@@ -32,7 +34,9 @@
       "artifacts" : [
         {
           "name" : "scala-library.jar",
-          "hash" : "sha1:3509860bc2e5b3da001ed45aca94ffbe5694dbda"
+          "sha1" : "sha1:3509860bc2e5b3da001ed45aca94ffbe5694dbda",
+          "sha256" : "sha256:0a57044d10895f8d3dd66ad4286891f607169d948845ac51e17b4c1cf0ab569d",
+          "url" : "https://repo1.maven.org/maven2/org/scala-lang/scala-library/2.12.10/scala-library-2.12.10.jar"
         }
       ],
       "configurations" : [
@@ -48,7 +52,9 @@
       "artifacts" : [
         {
           "name" : "scala-reflect.jar",
-          "hash" : "sha1:14cb7beb516cd8e07716133668c427792122c926"
+          "sha1" : "sha1:14cb7beb516cd8e07716133668c427792122c926",
+          "sha256" : "sha256:56b609e1bab9144fb51525bfa01ccd72028154fc40a58685a1e9adcbe7835730",
+          "url" : "https://repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.12.10/scala-reflect-2.12.10.jar"
         }
       ],
       "configurations" : [
@@ -62,7 +68,9 @@
       "artifacts" : [
         {
           "name" : "scala-xml_2.12.jar",
-          "hash" : "sha1:5d38ac30beb8420dd395c0af447ba412158965e6"
+          "sha1" : "sha1:5d38ac30beb8420dd395c0af447ba412158965e6",
+          "sha256" : "sha256:1b48dc206f527b7604ef32492ada8e71706c63a65d999e0cabdafdc5793b4d63",
+          "url" : "https://repo1.maven.org/maven2/org/scala-lang/modules/scala-xml_2.12/1.2.0/scala-xml_2.12-1.2.0.jar"
         }
       ],
       "configurations" : [
@@ -76,7 +84,9 @@
       "artifacts" : [
         {
           "name" : "scalactic_2.12.jar",
-          "hash" : "sha1:b50559dfc4a691c1089f9c8812e1d6fd17f80277"
+          "sha1" : "sha1:b50559dfc4a691c1089f9c8812e1d6fd17f80277",
+          "sha256" : "sha256:5f9ad122f54e9a0112ff4fcaadfb2802d8796f5dde021caa4c831067fca68469",
+          "url" : "https://repo1.maven.org/maven2/org/scalactic/scalactic_2.12/3.0.8/scalactic_2.12-3.0.8.jar"
         }
       ],
       "configurations" : [
@@ -90,7 +100,9 @@
       "artifacts" : [
         {
           "name" : "scalatest_2.12.jar",
-          "hash" : "sha1:8493ffa579676977b810a7a9fdc23af9d3c8af7f"
+          "sha1" : "sha1:8493ffa579676977b810a7a9fdc23af9d3c8af7f",
+          "sha256" : "sha256:a4045cea66f3eaab525696f3000d7d610593778bd070e98349a7066f872844cd",
+          "url" : "https://repo1.maven.org/maven2/org/scalatest/scalatest_2.12/3.0.8/scalatest_2.12-3.0.8.jar"
         }
       ],
       "configurations" : [

--- a/src/sbt-test/update/auto-update-same/build.sbt.lock
+++ b/src/sbt-test/update/auto-update-same/build.sbt.lock
@@ -16,7 +16,9 @@
       "artifacts" : [
         {
           "name" : "commons-lang3.jar",
-          "hash" : "sha1:0122c7cee69b53ed4a7681c03d4ee4c0e2765da5"
+          "sha1" : "sha1:0122c7cee69b53ed4a7681c03d4ee4c0e2765da5",
+          "sha256" : "sha256:de2e1dcdcf3ef917a8ce858661a06726a9a944f28e33ad7f9e08bea44dc3c230",
+          "url" : "https://repo1.maven.org/maven2/org/apache/commons/commons-lang3/3.9/commons-lang3-3.9.jar"
         }
       ],
       "configurations" : [
@@ -32,7 +34,9 @@
       "artifacts" : [
         {
           "name" : "scala-library.jar",
-          "hash" : "sha1:3509860bc2e5b3da001ed45aca94ffbe5694dbda"
+          "sha1" : "sha1:3509860bc2e5b3da001ed45aca94ffbe5694dbda",
+          "sha256" : "sha256:0a57044d10895f8d3dd66ad4286891f607169d948845ac51e17b4c1cf0ab569d",
+          "url" : "https://repo1.maven.org/maven2/org/scala-lang/scala-library/2.12.10/scala-library-2.12.10.jar"
         }
       ],
       "configurations" : [
@@ -48,7 +52,9 @@
       "artifacts" : [
         {
           "name" : "scala-reflect.jar",
-          "hash" : "sha1:14cb7beb516cd8e07716133668c427792122c926"
+          "sha1" : "sha1:14cb7beb516cd8e07716133668c427792122c926",
+          "sha256" : "sha256:56b609e1bab9144fb51525bfa01ccd72028154fc40a58685a1e9adcbe7835730",
+          "url" : "https://repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.12.10/scala-reflect-2.12.10.jar"
         }
       ],
       "configurations" : [
@@ -62,7 +68,9 @@
       "artifacts" : [
         {
           "name" : "scala-xml_2.12.jar",
-          "hash" : "sha1:5d38ac30beb8420dd395c0af447ba412158965e6"
+          "sha1" : "sha1:5d38ac30beb8420dd395c0af447ba412158965e6",
+          "sha256" : "sha256:1b48dc206f527b7604ef32492ada8e71706c63a65d999e0cabdafdc5793b4d63",
+          "url" : "https://repo1.maven.org/maven2/org/scala-lang/modules/scala-xml_2.12/1.2.0/scala-xml_2.12-1.2.0.jar"
         }
       ],
       "configurations" : [
@@ -76,7 +84,9 @@
       "artifacts" : [
         {
           "name" : "scalactic_2.12.jar",
-          "hash" : "sha1:b50559dfc4a691c1089f9c8812e1d6fd17f80277"
+          "sha1" : "sha1:b50559dfc4a691c1089f9c8812e1d6fd17f80277",
+          "sha256" : "sha256:5f9ad122f54e9a0112ff4fcaadfb2802d8796f5dde021caa4c831067fca68469",
+          "url" : "https://repo1.maven.org/maven2/org/scalactic/scalactic_2.12/3.0.8/scalactic_2.12-3.0.8.jar"
         }
       ],
       "configurations" : [
@@ -90,7 +100,9 @@
       "artifacts" : [
         {
           "name" : "scalatest_2.12.jar",
-          "hash" : "sha1:8493ffa579676977b810a7a9fdc23af9d3c8af7f"
+          "sha1" : "sha1:8493ffa579676977b810a7a9fdc23af9d3c8af7f",
+          "sha256" : "sha256:a4045cea66f3eaab525696f3000d7d610593778bd070e98349a7066f872844cd",
+          "url" : "https://repo1.maven.org/maven2/org/scalatest/scalatest_2.12/3.0.8/scalatest_2.12-3.0.8.jar"
         }
       ],
       "configurations" : [

--- a/src/sbt-test/update/disabled-differences/build.sbt.lock
+++ b/src/sbt-test/update/disabled-differences/build.sbt.lock
@@ -16,7 +16,9 @@
       "artifacts" : [
         {
           "name" : "commons-lang3.jar",
-          "hash" : "sha1:0122c7cee69b53ed4a7681c03d4ee4c0e2765da5"
+          "sha1" : "sha1:0122c7cee69b53ed4a7681c03d4ee4c0e2765da5",
+          "sha256" : "sha256:de2e1dcdcf3ef917a8ce858661a06726a9a944f28e33ad7f9e08bea44dc3c230",
+          "url" : "https://repo1.maven.org/maven2/org/apache/commons/commons-lang3/3.9/commons-lang3-3.9.jar"
         }
       ],
       "configurations" : [
@@ -32,7 +34,9 @@
       "artifacts" : [
         {
           "name" : "scala-library.jar",
-          "hash" : "sha1:3509860bc2e5b3da001ed45aca94ffbe5694dbda"
+          "sha1" : "sha1:3509860bc2e5b3da001ed45aca94ffbe5694dbda",
+          "sha256" : "sha256:0a57044d10895f8d3dd66ad4286891f607169d948845ac51e17b4c1cf0ab569d",
+          "url" : "https://repo1.maven.org/maven2/org/scala-lang/scala-library/2.12.10/scala-library-2.12.10.jar"
         }
       ],
       "configurations" : [
@@ -48,7 +52,9 @@
       "artifacts" : [
         {
           "name" : "scala-reflect.jar",
-          "hash" : "sha1:14cb7beb516cd8e07716133668c427792122c926"
+          "sha1" : "sha1:14cb7beb516cd8e07716133668c427792122c926",
+          "sha256" : "sha256:56b609e1bab9144fb51525bfa01ccd72028154fc40a58685a1e9adcbe7835730",
+          "url" : "https://repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.12.10/scala-reflect-2.12.10.jar"
         }
       ],
       "configurations" : [
@@ -62,7 +68,9 @@
       "artifacts" : [
         {
           "name" : "scala-xml_2.12.jar",
-          "hash" : "sha1:5d38ac30beb8420dd395c0af447ba412158965e6"
+          "sha1" : "sha1:5d38ac30beb8420dd395c0af447ba412158965e6",
+          "sha256" : "sha256:1b48dc206f527b7604ef32492ada8e71706c63a65d999e0cabdafdc5793b4d63",
+          "url" : "https://repo1.maven.org/maven2/org/scala-lang/modules/scala-xml_2.12/1.2.0/scala-xml_2.12-1.2.0.jar"
         }
       ],
       "configurations" : [
@@ -76,7 +84,9 @@
       "artifacts" : [
         {
           "name" : "scalactic_2.12.jar",
-          "hash" : "sha1:b50559dfc4a691c1089f9c8812e1d6fd17f80277"
+          "sha1" : "sha1:b50559dfc4a691c1089f9c8812e1d6fd17f80277",
+          "sha256" : "sha256:5f9ad122f54e9a0112ff4fcaadfb2802d8796f5dde021caa4c831067fca68469",
+          "url" : "https://repo1.maven.org/maven2/org/scalactic/scalactic_2.12/3.0.8/scalactic_2.12-3.0.8.jar"
         }
       ],
       "configurations" : [
@@ -90,7 +100,9 @@
       "artifacts" : [
         {
           "name" : "scalatest_2.12.jar",
-          "hash" : "sha1:8493ffa579676977b810a7a9fdc23af9d3c8af7f"
+          "sha1" : "sha1:8493ffa579676977b810a7a9fdc23af9d3c8af7f",
+          "sha256" : "sha256:a4045cea66f3eaab525696f3000d7d610593778bd070e98349a7066f872844cd",
+          "url" : "https://repo1.maven.org/maven2/org/scalatest/scalatest_2.12/3.0.8/scalatest_2.12-3.0.8.jar"
         }
       ],
       "configurations" : [

--- a/src/sbt-test/update/disabled-same/build.sbt.lock
+++ b/src/sbt-test/update/disabled-same/build.sbt.lock
@@ -16,7 +16,9 @@
       "artifacts" : [
         {
           "name" : "commons-lang3.jar",
-          "hash" : "sha1:0122c7cee69b53ed4a7681c03d4ee4c0e2765da5"
+          "sha1" : "sha1:0122c7cee69b53ed4a7681c03d4ee4c0e2765da5",
+          "sha256" : "sha256:de2e1dcdcf3ef917a8ce858661a06726a9a944f28e33ad7f9e08bea44dc3c230",
+          "url" : "https://repo1.maven.org/maven2/org/apache/commons/commons-lang3/3.9/commons-lang3-3.9.jar"
         }
       ],
       "configurations" : [
@@ -32,7 +34,9 @@
       "artifacts" : [
         {
           "name" : "scala-library.jar",
-          "hash" : "sha1:3509860bc2e5b3da001ed45aca94ffbe5694dbda"
+          "sha1" : "sha1:3509860bc2e5b3da001ed45aca94ffbe5694dbda",
+          "sha256" : "sha256:0a57044d10895f8d3dd66ad4286891f607169d948845ac51e17b4c1cf0ab569d",
+          "url" : "https://repo1.maven.org/maven2/org/scala-lang/scala-library/2.12.10/scala-library-2.12.10.jar"
         }
       ],
       "configurations" : [
@@ -48,7 +52,9 @@
       "artifacts" : [
         {
           "name" : "scala-reflect.jar",
-          "hash" : "sha1:14cb7beb516cd8e07716133668c427792122c926"
+          "sha1" : "sha1:14cb7beb516cd8e07716133668c427792122c926",
+          "sha256" : "sha256:56b609e1bab9144fb51525bfa01ccd72028154fc40a58685a1e9adcbe7835730",
+          "url" : "https://repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.12.10/scala-reflect-2.12.10.jar"
         }
       ],
       "configurations" : [
@@ -62,7 +68,9 @@
       "artifacts" : [
         {
           "name" : "scala-xml_2.12.jar",
-          "hash" : "sha1:5d38ac30beb8420dd395c0af447ba412158965e6"
+          "sha1" : "sha1:5d38ac30beb8420dd395c0af447ba412158965e6",
+          "sha256" : "sha256:1b48dc206f527b7604ef32492ada8e71706c63a65d999e0cabdafdc5793b4d63",
+          "url" : "https://repo1.maven.org/maven2/org/scala-lang/modules/scala-xml_2.12/1.2.0/scala-xml_2.12-1.2.0.jar"
         }
       ],
       "configurations" : [
@@ -76,7 +84,9 @@
       "artifacts" : [
         {
           "name" : "scalactic_2.12.jar",
-          "hash" : "sha1:b50559dfc4a691c1089f9c8812e1d6fd17f80277"
+          "sha1" : "sha1:b50559dfc4a691c1089f9c8812e1d6fd17f80277",
+          "sha256" : "sha256:5f9ad122f54e9a0112ff4fcaadfb2802d8796f5dde021caa4c831067fca68469",
+          "url" : "https://repo1.maven.org/maven2/org/scalactic/scalactic_2.12/3.0.8/scalactic_2.12-3.0.8.jar"
         }
       ],
       "configurations" : [
@@ -90,7 +100,9 @@
       "artifacts" : [
         {
           "name" : "scalatest_2.12.jar",
-          "hash" : "sha1:8493ffa579676977b810a7a9fdc23af9d3c8af7f"
+          "sha1" : "sha1:8493ffa579676977b810a7a9fdc23af9d3c8af7f",
+          "sha256" : "sha256:a4045cea66f3eaab525696f3000d7d610593778bd070e98349a7066f872844cd",
+          "url" : "https://repo1.maven.org/maven2/org/scalatest/scalatest_2.12/3.0.8/scalatest_2.12-3.0.8.jar"
         }
       ],
       "configurations" : [

--- a/src/sbt-test/update/fail-differences/build.sbt.lock
+++ b/src/sbt-test/update/fail-differences/build.sbt.lock
@@ -16,7 +16,9 @@
       "artifacts" : [
         {
           "name" : "commons-lang3.jar",
-          "hash" : "sha1:0122c7cee69b53ed4a7681c03d4ee4c0e2765da5"
+          "sha1" : "sha1:0122c7cee69b53ed4a7681c03d4ee4c0e2765da5",
+          "sha256" : "sha256:de2e1dcdcf3ef917a8ce858661a06726a9a944f28e33ad7f9e08bea44dc3c230",
+          "url" : "https://repo1.maven.org/maven2/org/apache/commons/commons-lang3/3.9/commons-lang3-3.9.jar"
         }
       ],
       "configurations" : [
@@ -32,7 +34,9 @@
       "artifacts" : [
         {
           "name" : "scala-library.jar",
-          "hash" : "sha1:3509860bc2e5b3da001ed45aca94ffbe5694dbda"
+          "sha1" : "sha1:3509860bc2e5b3da001ed45aca94ffbe5694dbda",
+          "sha256" : "sha256:0a57044d10895f8d3dd66ad4286891f607169d948845ac51e17b4c1cf0ab569d",
+          "url" : "https://repo1.maven.org/maven2/org/scala-lang/scala-library/2.12.10/scala-library-2.12.10.jar"
         }
       ],
       "configurations" : [
@@ -48,7 +52,9 @@
       "artifacts" : [
         {
           "name" : "scala-reflect.jar",
-          "hash" : "sha1:14cb7beb516cd8e07716133668c427792122c926"
+          "sha1" : "sha1:14cb7beb516cd8e07716133668c427792122c926",
+          "sha256" : "sha256:56b609e1bab9144fb51525bfa01ccd72028154fc40a58685a1e9adcbe7835730",
+          "url" : "https://repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.12.10/scala-reflect-2.12.10.jar"
         }
       ],
       "configurations" : [
@@ -62,7 +68,9 @@
       "artifacts" : [
         {
           "name" : "scala-xml_2.12.jar",
-          "hash" : "sha1:5d38ac30beb8420dd395c0af447ba412158965e6"
+          "sha1" : "sha1:5d38ac30beb8420dd395c0af447ba412158965e6",
+          "sha256" : "sha256:1b48dc206f527b7604ef32492ada8e71706c63a65d999e0cabdafdc5793b4d63",
+          "url" : "https://repo1.maven.org/maven2/org/scala-lang/modules/scala-xml_2.12/1.2.0/scala-xml_2.12-1.2.0.jar"
         }
       ],
       "configurations" : [
@@ -76,7 +84,9 @@
       "artifacts" : [
         {
           "name" : "scalactic_2.12.jar",
-          "hash" : "sha1:b50559dfc4a691c1089f9c8812e1d6fd17f80277"
+          "sha1" : "sha1:b50559dfc4a691c1089f9c8812e1d6fd17f80277",
+          "sha256" : "sha256:5f9ad122f54e9a0112ff4fcaadfb2802d8796f5dde021caa4c831067fca68469",
+          "url" : "https://repo1.maven.org/maven2/org/scalactic/scalactic_2.12/3.0.8/scalactic_2.12-3.0.8.jar"
         }
       ],
       "configurations" : [
@@ -90,7 +100,9 @@
       "artifacts" : [
         {
           "name" : "scalatest_2.12.jar",
-          "hash" : "sha1:8493ffa579676977b810a7a9fdc23af9d3c8af7f"
+          "sha1" : "sha1:8493ffa579676977b810a7a9fdc23af9d3c8af7f",
+          "sha256" : "sha256:a4045cea66f3eaab525696f3000d7d610593778bd070e98349a7066f872844cd",
+          "url" : "https://repo1.maven.org/maven2/org/scalatest/scalatest_2.12/3.0.8/scalatest_2.12-3.0.8.jar"
         }
       ],
       "configurations" : [

--- a/src/sbt-test/update/fail-same/build.sbt.lock
+++ b/src/sbt-test/update/fail-same/build.sbt.lock
@@ -16,7 +16,9 @@
       "artifacts" : [
         {
           "name" : "commons-lang3.jar",
-          "hash" : "sha1:0122c7cee69b53ed4a7681c03d4ee4c0e2765da5"
+          "sha1" : "sha1:0122c7cee69b53ed4a7681c03d4ee4c0e2765da5",
+          "sha256" : "sha256:de2e1dcdcf3ef917a8ce858661a06726a9a944f28e33ad7f9e08bea44dc3c230",
+          "url" : "https://repo1.maven.org/maven2/org/apache/commons/commons-lang3/3.9/commons-lang3-3.9.jar"
         }
       ],
       "configurations" : [
@@ -32,7 +34,9 @@
       "artifacts" : [
         {
           "name" : "scala-library.jar",
-          "hash" : "sha1:3509860bc2e5b3da001ed45aca94ffbe5694dbda"
+          "sha1" : "sha1:3509860bc2e5b3da001ed45aca94ffbe5694dbda",
+          "sha256" : "sha256:0a57044d10895f8d3dd66ad4286891f607169d948845ac51e17b4c1cf0ab569d",
+          "url" : "https://repo1.maven.org/maven2/org/scala-lang/scala-library/2.12.10/scala-library-2.12.10.jar"
         }
       ],
       "configurations" : [
@@ -48,7 +52,9 @@
       "artifacts" : [
         {
           "name" : "scala-reflect.jar",
-          "hash" : "sha1:14cb7beb516cd8e07716133668c427792122c926"
+          "sha1" : "sha1:14cb7beb516cd8e07716133668c427792122c926",
+          "sha256" : "sha256:56b609e1bab9144fb51525bfa01ccd72028154fc40a58685a1e9adcbe7835730",
+          "url" : "https://repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.12.10/scala-reflect-2.12.10.jar"
         }
       ],
       "configurations" : [
@@ -62,7 +68,9 @@
       "artifacts" : [
         {
           "name" : "scala-xml_2.12.jar",
-          "hash" : "sha1:5d38ac30beb8420dd395c0af447ba412158965e6"
+          "sha1" : "sha1:5d38ac30beb8420dd395c0af447ba412158965e6",
+          "sha256" : "sha256:1b48dc206f527b7604ef32492ada8e71706c63a65d999e0cabdafdc5793b4d63",
+          "url" : "https://repo1.maven.org/maven2/org/scala-lang/modules/scala-xml_2.12/1.2.0/scala-xml_2.12-1.2.0.jar"
         }
       ],
       "configurations" : [
@@ -76,7 +84,9 @@
       "artifacts" : [
         {
           "name" : "scalactic_2.12.jar",
-          "hash" : "sha1:b50559dfc4a691c1089f9c8812e1d6fd17f80277"
+          "sha1" : "sha1:b50559dfc4a691c1089f9c8812e1d6fd17f80277",
+          "sha256" : "sha256:5f9ad122f54e9a0112ff4fcaadfb2802d8796f5dde021caa4c831067fca68469",
+          "url" : "https://repo1.maven.org/maven2/org/scalactic/scalactic_2.12/3.0.8/scalactic_2.12-3.0.8.jar"
         }
       ],
       "configurations" : [
@@ -90,7 +100,9 @@
       "artifacts" : [
         {
           "name" : "scalatest_2.12.jar",
-          "hash" : "sha1:8493ffa579676977b810a7a9fdc23af9d3c8af7f"
+          "sha1" : "sha1:8493ffa579676977b810a7a9fdc23af9d3c8af7f",
+          "sha256" : "sha256:a4045cea66f3eaab525696f3000d7d610593778bd070e98349a7066f872844cd",
+          "url" : "https://repo1.maven.org/maven2/org/scalatest/scalatest_2.12/3.0.8/scalatest_2.12-3.0.8.jar"
         }
       ],
       "configurations" : [

--- a/src/sbt-test/update/warn-differences/build.sbt.lock
+++ b/src/sbt-test/update/warn-differences/build.sbt.lock
@@ -16,7 +16,9 @@
       "artifacts" : [
         {
           "name" : "commons-lang3.jar",
-          "hash" : "sha1:0122c7cee69b53ed4a7681c03d4ee4c0e2765da5"
+          "sha1" : "sha1:0122c7cee69b53ed4a7681c03d4ee4c0e2765da5",
+          "sha256" : "sha256:de2e1dcdcf3ef917a8ce858661a06726a9a944f28e33ad7f9e08bea44dc3c230",
+          "url" : "https://repo1.maven.org/maven2/org/apache/commons/commons-lang3/3.9/commons-lang3-3.9.jar"
         }
       ],
       "configurations" : [
@@ -32,7 +34,9 @@
       "artifacts" : [
         {
           "name" : "scala-library.jar",
-          "hash" : "sha1:3509860bc2e5b3da001ed45aca94ffbe5694dbda"
+          "sha1" : "sha1:3509860bc2e5b3da001ed45aca94ffbe5694dbda",
+          "sha256" : "sha256:0a57044d10895f8d3dd66ad4286891f607169d948845ac51e17b4c1cf0ab569d",
+          "url" : "https://repo1.maven.org/maven2/org/scala-lang/scala-library/2.12.10/scala-library-2.12.10.jar"
         }
       ],
       "configurations" : [
@@ -48,7 +52,9 @@
       "artifacts" : [
         {
           "name" : "scala-reflect.jar",
-          "hash" : "sha1:14cb7beb516cd8e07716133668c427792122c926"
+          "sha1" : "sha1:14cb7beb516cd8e07716133668c427792122c926",
+          "sha256" : "sha256:56b609e1bab9144fb51525bfa01ccd72028154fc40a58685a1e9adcbe7835730",
+          "url" : "https://repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.12.10/scala-reflect-2.12.10.jar"
         }
       ],
       "configurations" : [
@@ -62,7 +68,9 @@
       "artifacts" : [
         {
           "name" : "scala-xml_2.12.jar",
-          "hash" : "sha1:5d38ac30beb8420dd395c0af447ba412158965e6"
+          "sha1" : "sha1:5d38ac30beb8420dd395c0af447ba412158965e6",
+          "sha256" : "sha256:1b48dc206f527b7604ef32492ada8e71706c63a65d999e0cabdafdc5793b4d63",
+          "url" : "https://repo1.maven.org/maven2/org/scala-lang/modules/scala-xml_2.12/1.2.0/scala-xml_2.12-1.2.0.jar"
         }
       ],
       "configurations" : [
@@ -76,7 +84,9 @@
       "artifacts" : [
         {
           "name" : "scalactic_2.12.jar",
-          "hash" : "sha1:b50559dfc4a691c1089f9c8812e1d6fd17f80277"
+          "sha1" : "sha1:b50559dfc4a691c1089f9c8812e1d6fd17f80277",
+          "sha256" : "sha256:5f9ad122f54e9a0112ff4fcaadfb2802d8796f5dde021caa4c831067fca68469",
+          "url" : "https://repo1.maven.org/maven2/org/scalactic/scalactic_2.12/3.0.8/scalactic_2.12-3.0.8.jar"
         }
       ],
       "configurations" : [
@@ -90,7 +100,9 @@
       "artifacts" : [
         {
           "name" : "scalatest_2.12.jar",
-          "hash" : "sha1:8493ffa579676977b810a7a9fdc23af9d3c8af7f"
+          "sha1" : "sha1:8493ffa579676977b810a7a9fdc23af9d3c8af7f",
+          "sha256" : "sha256:a4045cea66f3eaab525696f3000d7d610593778bd070e98349a7066f872844cd",
+          "url" : "https://repo1.maven.org/maven2/org/scalatest/scalatest_2.12/3.0.8/scalatest_2.12-3.0.8.jar"
         }
       ],
       "configurations" : [

--- a/src/sbt-test/update/warn-same/build.sbt.lock
+++ b/src/sbt-test/update/warn-same/build.sbt.lock
@@ -16,7 +16,9 @@
       "artifacts" : [
         {
           "name" : "commons-lang3.jar",
-          "hash" : "sha1:0122c7cee69b53ed4a7681c03d4ee4c0e2765da5"
+          "sha1" : "sha1:0122c7cee69b53ed4a7681c03d4ee4c0e2765da5",
+          "sha256" : "sha256:de2e1dcdcf3ef917a8ce858661a06726a9a944f28e33ad7f9e08bea44dc3c230",
+          "url" : "https://repo1.maven.org/maven2/org/apache/commons/commons-lang3/3.9/commons-lang3-3.9.jar"
         }
       ],
       "configurations" : [
@@ -32,7 +34,9 @@
       "artifacts" : [
         {
           "name" : "scala-library.jar",
-          "hash" : "sha1:3509860bc2e5b3da001ed45aca94ffbe5694dbda"
+          "sha1" : "sha1:3509860bc2e5b3da001ed45aca94ffbe5694dbda",
+          "sha256" : "sha256:0a57044d10895f8d3dd66ad4286891f607169d948845ac51e17b4c1cf0ab569d",
+          "url" : "https://repo1.maven.org/maven2/org/scala-lang/scala-library/2.12.10/scala-library-2.12.10.jar"
         }
       ],
       "configurations" : [
@@ -48,7 +52,9 @@
       "artifacts" : [
         {
           "name" : "scala-reflect.jar",
-          "hash" : "sha1:14cb7beb516cd8e07716133668c427792122c926"
+          "sha1" : "sha1:14cb7beb516cd8e07716133668c427792122c926",
+          "sha256" : "sha256:56b609e1bab9144fb51525bfa01ccd72028154fc40a58685a1e9adcbe7835730",
+          "url" : "https://repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.12.10/scala-reflect-2.12.10.jar"
         }
       ],
       "configurations" : [
@@ -62,7 +68,9 @@
       "artifacts" : [
         {
           "name" : "scala-xml_2.12.jar",
-          "hash" : "sha1:5d38ac30beb8420dd395c0af447ba412158965e6"
+          "sha1" : "sha1:5d38ac30beb8420dd395c0af447ba412158965e6",
+          "sha256" : "sha256:1b48dc206f527b7604ef32492ada8e71706c63a65d999e0cabdafdc5793b4d63",
+          "url" : "https://repo1.maven.org/maven2/org/scala-lang/modules/scala-xml_2.12/1.2.0/scala-xml_2.12-1.2.0.jar"
         }
       ],
       "configurations" : [
@@ -76,7 +84,9 @@
       "artifacts" : [
         {
           "name" : "scalactic_2.12.jar",
-          "hash" : "sha1:b50559dfc4a691c1089f9c8812e1d6fd17f80277"
+          "sha1" : "sha1:b50559dfc4a691c1089f9c8812e1d6fd17f80277",
+          "sha256" : "sha256:5f9ad122f54e9a0112ff4fcaadfb2802d8796f5dde021caa4c831067fca68469",
+          "url" : "https://repo1.maven.org/maven2/org/scalactic/scalactic_2.12/3.0.8/scalactic_2.12-3.0.8.jar"
         }
       ],
       "configurations" : [
@@ -90,7 +100,9 @@
       "artifacts" : [
         {
           "name" : "scalatest_2.12.jar",
-          "hash" : "sha1:8493ffa579676977b810a7a9fdc23af9d3c8af7f"
+          "sha1" : "sha1:8493ffa579676977b810a7a9fdc23af9d3c8af7f",
+          "sha256" : "sha256:a4045cea66f3eaab525696f3000d7d610593778bd070e98349a7066f872844cd",
+          "url" : "https://repo1.maven.org/maven2/org/scalatest/scalatest_2.12/3.0.8/scalatest_2.12-3.0.8.jar"
         }
       ],
       "configurations" : [

--- a/src/test/scala/software/purpledragon/sbt/lock/model/DependencyLockFileSpec.scala
+++ b/src/test/scala/software/purpledragon/sbt/lock/model/DependencyLockFileSpec.scala
@@ -34,7 +34,7 @@ class DependencyLockFileSpec extends AnyFlatSpec with Matchers {
         "com.example",
         "package-1",
         "1.0.0",
-        SortedSet(ResolvedArtifact("package-1.jar", "hash-1")),
+        SortedSet(ResolvedArtifact("package-1.jar", "hash-1", "hash-2", None)),
         SortedSet("test-1")),
       ResolvedDependency("com.example", "package-2", "1.2.0", SortedSet.empty, SortedSet("test-2")),
     ),
@@ -82,7 +82,7 @@ class DependencyLockFileSpec extends AnyFlatSpec with Matchers {
       "com.example",
       "package-3",
       "3.0",
-      SortedSet(ResolvedArtifact("package-3.jar", "hash-3")),
+      SortedSet(ResolvedArtifact("package-3.jar", "hash-3", "hash-4", None)),
       SortedSet("test-1"))
 
     val left = TestLockFile
@@ -105,7 +105,7 @@ class DependencyLockFileSpec extends AnyFlatSpec with Matchers {
         "com.example",
         "package-1",
         "2.0.0",
-        SortedSet(ResolvedArtifact("package-1.jar", "hash-1a")),
+        SortedSet(ResolvedArtifact("package-1.jar", "hash-1a", "hash-2a", None)),
         SortedSet("test-1", "test-2")),
     )
 
@@ -120,8 +120,8 @@ class DependencyLockFileSpec extends AnyFlatSpec with Matchers {
           "package-1",
           "1.0.0",
           "2.0.0",
-          SortedSet(ResolvedArtifact("package-1.jar", "hash-1")),
-          SortedSet(ResolvedArtifact("package-1.jar", "hash-1a")),
+          SortedSet(ResolvedArtifact("package-1.jar", "hash-1", "hash-2", None)),
+          SortedSet(ResolvedArtifact("package-1.jar", "hash-1a", "hash-2a", None)),
           SortedSet("test-1"),
           SortedSet("test-1", "test-2"),
         )),

--- a/src/test/scala/software/purpledragon/sbt/lock/model/LockFileStatusSpec.scala
+++ b/src/test/scala/software/purpledragon/sbt/lock/model/LockFileStatusSpec.scala
@@ -101,15 +101,17 @@ class LockFileStatusSpec extends AnyFlatSpec with Matchers {
           testChangedDependencyArtifacts(
             "dependency-1",
             "1.1",
-            oldArtifacts = Seq(ResolvedArtifact("artifact-2.jar", "sha1:07c10d545325e3a6e72e06381afe469fd40eb701")),
-            newArtifacts = Seq(ResolvedArtifact("artifact-1.jar", "sha1:2b8b815229aa8a61e483fb4ba0588b8b6c491890")),
+            oldArtifacts = Seq(
+              ResolvedArtifact("artifact-2.jar", "sha1:07c10d545325e3a6e72e06381afe469fd40eb701", "sha256:a", None)),
+            newArtifacts =
+              Seq(ResolvedArtifact("artifact-1.jar", "sha1:2b8b815229aa8a61e483fb4ba0588b8b6c491890", "sha256:b", None)),
           ),
           testChangedDependencyArtifacts(
             "dependency-2",
             "1.1.2",
             oldArtifacts = Seq(
-              ResolvedArtifact("artifact-a.jar", "sha1:07c10d545325e3a6e72e06381afe469fd40eb701"),
-              ResolvedArtifact("artifact-b.jar", "sha1:cfa4f316351a91bfd95cb0644c6a2c95f52db1fc"),
+              ResolvedArtifact("artifact-a.jar", "sha1:07c10d545325e3a6e72e06381afe469fd40eb701", "sha256:a", None),
+              ResolvedArtifact("artifact-b.jar", "sha1:cfa4f316351a91bfd95cb0644c6a2c95f52db1fc", "sha256:b", None),
             ),
           ),
         ),
@@ -222,15 +224,17 @@ class LockFileStatusSpec extends AnyFlatSpec with Matchers {
           testChangedDependencyArtifacts(
             "dependency-1",
             "1.1",
-            oldArtifacts = Seq(ResolvedArtifact("artifact-2.jar", "sha1:07c10d545325e3a6e72e06381afe469fd40eb701")),
-            newArtifacts = Seq(ResolvedArtifact("artifact-1.jar", "sha1:2b8b815229aa8a61e483fb4ba0588b8b6c491890")),
+            oldArtifacts = Seq(
+              ResolvedArtifact("artifact-2.jar", "sha1:07c10d545325e3a6e72e06381afe469fd40eb701", "sha256:a", None)),
+            newArtifacts =
+              Seq(ResolvedArtifact("artifact-1.jar", "sha1:2b8b815229aa8a61e483fb4ba0588b8b6c491890", "sha256:b", None)),
           ),
           testChangedDependencyArtifacts(
             "dependency-2",
             "1.1.2",
             oldArtifacts = Seq(
-              ResolvedArtifact("artifact-a.jar", "sha1:07c10d545325e3a6e72e06381afe469fd40eb701"),
-              ResolvedArtifact("artifact-b.jar", "sha1:cfa4f316351a91bfd95cb0644c6a2c95f52db1fc"),
+              ResolvedArtifact("artifact-a.jar", "sha1:07c10d545325e3a6e72e06381afe469fd40eb701", "sha256:a", None),
+              ResolvedArtifact("artifact-b.jar", "sha1:cfa4f316351a91bfd95cb0644c6a2c95f52db1fc", "sha256:b", None),
             ),
           ),
         ),


### PR DESCRIPTION
### Change Description

This PR is a _first draft_ for augmenting the build.sbt.lock files with the following information:

- Absolute URL for each artifact, allowing download of these without a resolution process.
- SHA-256 hash for each artifact, as an addition to the existing SHA-1 hash available.

The SHA-256 hashing is based on the SHA-1 hash implementation using MessageDigest from sbt.io.Hash. It has pretty much just been lifted out, and had the hash algorithm changed for MessageDigest.

Besides these additions, I have made the following changes to the build.sbt.lock file format:

- Renamed the artifact "hash" attribute to "sha1", so it's a bit more consistent with the newly added "sha256" attribute.

Renaming the hash-attribute makes this PR backwards **incompatible** with existing lockfiles. It is my impression, that these lockfiles can be easily regenerated when updating the plugin version, but I welcome feedback on this decision, and any suggestions related to it.

Of other decisions worth considering; I decided **not** to include the artifact url in the `compare` method of `ResolvedArtifact`, as I felt it was a bit irrelevant if the same artifact was found at a different URL, as long as the hashes of the actual artifacts remained unchanged.

### Rationale

My motivation for doing this PR comes from a desire to be able to build SBT Scala projects with NixOS, and the normal artifact resolution process is problematic in this context, and ideally, each external dependency should have a download URL and SHA-256 hash known in advance. It seems to me, that sbt-dependency-lock is very well suited for recording this information in the build.sbt.lock files.

I hope we can find a solution that is acceptable to this project, where we can add this information to the files.

### Tests and style

The corresponding test fixtures have been updated, and I have tried to minimize any kind of diff-noise in these, so it's hopefully clear that I haven't inadvertently caused any test regressions by changing the fixtures too much.

I have run tests, scripted, headerCheck, and scalafmt on source files in both main and test.

### Feedback

As I have noted, I consider this a first draft of this PR, and I expect there to be feedback. I'm willing to continue working on it, based on the feedback, if you see any potential of getting something like this merged.

I was initially looking for a Discord or related, where I could coordinate what a solution should look like, but it seems the Issue-list is the preferred choice of this project, and then I thought I might as well push a suggestion as a starting point.

