### PR TITLE
Update dependencies & switch to Scala 3 sources

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version = 3.6.1
+version = 3.8.2
 runner.dialect = scala212source3
 
 maxColumn = 120

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 name         := "sbt-dependency-lock"
 organization := "software.purpledragon"
 
-enablePlugins(SbtPlugin, ParadoxSitePlugin, GhpagesPlugin)
+enablePlugins(SbtPlugin, SitePreviewPlugin, ParadoxSitePlugin, GhpagesPlugin)
 
 val circeVersion = "0.14.3"
 

--- a/build.sbt
+++ b/build.sbt
@@ -25,7 +25,7 @@ scriptedLaunchOpts           := {
     Seq("-Xmx1024M", "-Dplugin.version=" + version.value)
 }
 
-ThisBuild / scapegoatVersion := "2.1.0"
+ThisBuild / scapegoatVersion := "2.1.6"
 
 developers := List(
   Developer("stringbean", "Michael Stringer", "@the_stringbean", url("https://github.com/stringbean")),

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ organization := "software.purpledragon"
 
 enablePlugins(SbtPlugin, SitePreviewPlugin, ParadoxSitePlugin, GhpagesPlugin)
 
-val circeVersion = "0.14.3"
+val circeVersion = "0.14.9"
 
 libraryDependencies ++= Seq(
   "io.circe" %% "circe-core",
@@ -13,12 +13,12 @@ libraryDependencies ++= Seq(
 
 libraryDependencies ++= Seq(
   "software.purpledragon" %% "text-utils" % "1.3.1",
-  "org.scalatest"         %% "scalatest"  % "3.2.14" % Test,
+  "org.scalatest"         %% "scalatest"  % "3.2.19" % Test,
 )
 
 organizationName := "Michael Stringer"
 startYear        := Some(2019)
-licenses += ("Apache-2.0", new URL("https://www.apache.org/licenses/LICENSE-2.0.txt"))
+licenses += ("Apache-2.0", url("https://www.apache.org/licenses/LICENSE-2.0.txt"))
 
 scriptedLaunchOpts           := {
   scriptedLaunchOpts.value ++
@@ -39,7 +39,7 @@ scmInfo        := Some(
 git.remoteRepo := "git@github.com:stringbean/sbt-dependency-lock.git"
 publishTo      := sonatypePublishToBundle.value
 
-import sbtrelease.ReleasePlugin.autoImport.ReleaseTransformations._
+import sbtrelease.ReleasePlugin.autoImport.ReleaseTransformations.*
 
 releasePublishArtifactsAction := PgpKeys.publishSigned.value
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.8.0
+sbt.version=1.10.0

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,7 +5,7 @@ addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.13")
 
 // code style
 addSbtPlugin("de.heikoseeberger"       % "sbt-header"    % "5.7.0")
-addSbtPlugin("com.sksamuel.scapegoat" %% "sbt-scapegoat" % "1.1.1")
+addSbtPlugin("com.sksamuel.scapegoat" %% "sbt-scapegoat" % "1.2.4")
 addSbtPlugin("org.scalameta"           % "sbt-scalafmt"  % "2.4.6")
 
 // documentation

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,14 +1,13 @@
 // publishing
-addSbtPlugin("com.github.sbt" % "sbt-pgp"      % "2.1.2")
-addSbtPlugin("com.github.sbt" % "sbt-release"  % "1.1.0")
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.13")
+addSbtPlugin("com.github.sbt" % "sbt-pgp"      % "2.2.1")
+addSbtPlugin("com.github.sbt" % "sbt-release"  % "1.4.0")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.11.0")
 
 // code style
-addSbtPlugin("de.heikoseeberger"       % "sbt-header"    % "5.7.0")
+addSbtPlugin("de.heikoseeberger"       % "sbt-header"    % "5.10.0")
 addSbtPlugin("com.sksamuel.scapegoat" %% "sbt-scapegoat" % "1.2.4")
-addSbtPlugin("org.scalameta"           % "sbt-scalafmt"  % "2.4.6")
+addSbtPlugin("org.scalameta"           % "sbt-scalafmt"  % "2.5.2")
 
 // documentation
-addSbtPlugin("com.typesafe.sbt"      % "sbt-site"    % "1.4.1")
-addSbtPlugin("com.lightbend.paradox" % "sbt-paradox" % "0.10.2")
-addSbtPlugin("com.typesafe.sbt"      % "sbt-ghpages" % "0.6.3")
+addSbtPlugin("com.github.sbt" % "sbt-site-paradox" % "1.5.0")
+addSbtPlugin("com.github.sbt" % "sbt-ghpages"      % "0.8.0")

--- a/src/main/scala/software/purpledragon/sbt/lock/DependencyLockIO.scala
+++ b/src/main/scala/software/purpledragon/sbt/lock/DependencyLockIO.scala
@@ -18,10 +18,10 @@ package software.purpledragon.sbt.lock
 
 import java.io.File
 
-import io.circe.parser._
-import io.circe.syntax._
+import io.circe.parser.*
+import io.circe.syntax.*
 import sbt.io.IO
-import software.purpledragon.sbt.lock.model.Decoders._
+import software.purpledragon.sbt.lock.model.Decoders.*
 import software.purpledragon.sbt.lock.model.DependencyLockFile
 
 object DependencyLockIO {

--- a/src/main/scala/software/purpledragon/sbt/lock/DependencyLockPlugin.scala
+++ b/src/main/scala/software/purpledragon/sbt/lock/DependencyLockPlugin.scala
@@ -141,7 +141,7 @@ object DependencyLockPlugin extends AutoPlugin {
     }.value,
   )
 
-  override def globalSettings: Seq[Def.Setting[_]] = Seq(
+  override def globalSettings: Seq[Def.Setting[?]] = Seq(
     dependencyLockAutoCheck := DependencyLockUpdateMode.WarnOnError,
     dependencyLockModuleFilter := DependencyFilter.fnToModuleFilter(_ => false),
     dependencyLockConfigurationFilter := DependencyFilter.fnToConfigurationFilter(_ => false),

--- a/src/main/scala/software/purpledragon/sbt/lock/util/MessageUtil.scala
+++ b/src/main/scala/software/purpledragon/sbt/lock/util/MessageUtil.scala
@@ -25,11 +25,11 @@ object MessageUtil {
   val messages: ResourceBundle = ResourceBundle.getBundle("messages")
 
   def format(template: String, args: Any*): String = {
-    MessageFormat.format(template, args.map(unwrapArg): _*)
+    MessageFormat.format(template, args.map(unwrapArg)*)
   }
 
   def formatMessage(key: String, args: Any*): String = {
-    format(messages.getString(key), args.map(unwrapArg): _*)
+    format(messages.getString(key), args.map(unwrapArg)*)
   }
 
   def formatPlural(baseKey: String, count: Int, args: Any*): String = {
@@ -40,7 +40,7 @@ object MessageUtil {
     )
 
     val choice = new ChoiceFormat(Array(0, 1, 2), formatStrings)
-    format(choice.format(count), count +: args: _*)
+    format(choice.format(count), (count +: args)*)
   }
 
   @SuppressWarnings(Array("AsInstanceOf"))


### PR DESCRIPTION
Updates:

- sbt to 1.10.0.
- sbt plugins to the latest versions.
- Circe to 0.14.9.
- Remaining source code to Scala 3.

## Behaviour

_No changes._

## Does this PR require a lock file change?

No

## Checklist

- [x] I have read the CONTRIBUTING guidelines
- [x] User documentation has been updated
- [x] Unit and/or sbt tests have been added for the changes
- [x] I have run the following sbt commands:
  - [x] `test`
  - [x] `scripted`
  - [x] `scalafmt` & `test:scalafmt`
  - [x] `headerCheck` & `test:headerCheck`

## Description for the release notes

Dependency updates.
